### PR TITLE
Add capability to name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 0.6.1
+- Return the capability of a sensor as part of the name.
+
 ## 0.6.0 
 - Major structural change.  Using modules to avoid circular dependencies.
 - Added support for devices that contain multiple onboard sensors.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Python Wink API
 ---------------
 
+[![Join the chat at https://gitter.im/bradsk88/python-wink](https://badges.gitter.im/bradsk88/python-wink.svg)](https://gitter.im/bradsk88/python-wink?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
 _This script used to be part of Home Assistant. It has been extracted to fit
 the goal of Home Assistant to not contain any device specific API implementations
 but rely on open-source implementations of the API._

--- a/src/pywink/devices/sensors.py
+++ b/src/pywink/devices/sensors.py
@@ -25,6 +25,12 @@ class _WinkCapabilitySensor(WinkDevice):
     def capability(self):
         return self._capability
 
+    def name(self):
+        name = self.json_state.get('name', "Unknown Name")
+        if self._capability != "opened":
+            name += " " + self._capability
+        return name
+
     def device_id(self):
         root_name = self.json_state.get('sensor_pod_id', self.name())
         return '{}+{}'.format(root_name, self._capability)

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='python-wink',
-      version='0.6.0',
+      version='0.6.1',
       description='Access Wink devices via the Wink API',
       url='http://github.com/bradsk88/python-wink',
       author='Brad Johnson',


### PR DESCRIPTION
While trying to work on an HA pull request for the spotter, I noticed that the spotter sensors are all displayed in HA as sensor.spotter_#. I think it would be nice to have them listed as sensor.spotter_capability. This PR does that. It doesn't return the capability on motion and door/window sensors.
