### PR TITLE
Added values JSON to binary switch set_state

### DIFF
--- a/src/pywink/devices/standard.py
+++ b/src/pywink/devices/standard.py
@@ -67,7 +67,12 @@ class WinkBinarySwitch(WinkDevice):
         :param state:   a boolean of true (on) or false ('off')
         :return: nothing
         """
-        response = self.api_interface.set_device_state(self, state)
+        values = {
+            "desired_state": {
+                "powered": state
+            }
+        }
+        response = self.api_interface.set_device_state(self, values)
         self._update_state_from_response(response)
 
         self._last_call = (time.time(), state)


### PR DESCRIPTION
Looks like during the refactoring to 0.5.0 the set_state method got a little messed up. @TDWhbp reported the problem with generic zwave switches. Since all of my switches inherent from the base Binary switch, the set_state method is overridden and thats why it wasn't caught in testing. @TDWhbp was able to test this and reported that it does in fact fix the issue.
