### PR TITLE
Add method for reporting the current "connection" status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 0.6.4
+- Added available method to report "connection" status
+
 ## 0.6.3
 - Override capability sensor device_id during update.
 

--- a/src/pywink/devices/base.py
+++ b/src/pywink/devices/base.py
@@ -31,6 +31,13 @@ class WinkDevice(object):
     def _last_reading(self):
         return self.json_state.get('last_reading') or {}
 
+    @property
+    def available(self):
+        if not self._last_reading.get('connection', False):
+            return False
+        else:
+            return True
+
     def _update_state_from_response(self, response_json):
         """
         :param response_json: the json obj returned from query

--- a/src/pywink/devices/base.py
+++ b/src/pywink/devices/base.py
@@ -33,10 +33,7 @@ class WinkDevice(object):
 
     @property
     def available(self):
-        if not self._last_reading.get('connection', False):
-            return False
-        else:
-            return True
+        return self._last_reading.get('connection', False)
 
     def _update_state_from_response(self, response_json):
         """

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='python-wink',
-      version='0.6.3',
+      version='0.6.4',
       description='Access Wink devices via the Wink API',
       url='http://github.com/bradsk88/python-wink',
       author='Brad Johnson',


### PR DESCRIPTION
This will add the ability to indicate the devices availability to the app. 

This is useful for indicating to the user why a request wasn't successful.  Prior to this addition the app e.g. (Home-Assistant) would allow the user to make a request to a device even if it was offline. Making this request would result in no change of the device which is confusing to the user. This update, will allow an update to Home-Assistant to "disable" the device in the front-end.
