### PR TITLE
Added Wink Key support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 0.7.9
+- Added Wink keys (Wink Lock user codes)
+
 ## 0.7.8
 - Added support for retrieving the Pubnub subscription details
 

--- a/src/pywink/__init__.py
+++ b/src/pywink/__init__.py
@@ -5,5 +5,5 @@ Top level functions
 from pywink.api import set_bearer_token, set_wink_credentials, get_bulbs, \
     get_eggtrays, get_garage_doors, get_locks, get_powerstrip_outlets, \
     get_sensors, get_shades, get_sirens, get_switches, get_devices, \
-    is_token_set, get_subscription_key
+    is_token_set, get_subscription_key, get_keys
 

--- a/src/pywink/api.py
+++ b/src/pywink/api.py
@@ -106,6 +106,10 @@ def get_sirens():
     return get_devices(device_types.SIREN)
 
 
+def get_keys():
+    return get_devices(device_types.KEY)
+
+
 def get_subscription_key():
     response_dict = wink_api_fetch()
     first_device = response_dict.get('data')[0]

--- a/src/pywink/devices/factory.py
+++ b/src/pywink/devices/factory.py
@@ -1,7 +1,7 @@
 from pywink.devices.base import WinkDevice
 from pywink.devices.sensors import WinkSensorPod
 from pywink.devices.standard import WinkBulb, WinkBinarySwitch, WinkPowerStripOutlet, WinkLock, \
-    WinkEggTray, WinkGarageDoor, WinkShade, WinkSiren
+    WinkEggTray, WinkGarageDoor, WinkShade, WinkSiren, WinkKey
 
 
 def build_device(device_state_as_json, api_interface):
@@ -29,5 +29,7 @@ def build_device(device_state_as_json, api_interface):
         new_object = WinkShade(device_state_as_json, api_interface)
     elif "siren_id" in device_state_as_json:
         new_object = WinkSiren(device_state_as_json, api_interface)
+    elif "key_id" in device_state_as_json:
+        new_object = WinkKey(device_state_as_json, api_interface)
 
     return new_object or WinkDevice(device_state_as_json, api_interface)

--- a/src/pywink/devices/standard/__init__.py
+++ b/src/pywink/devices/standard/__init__.py
@@ -328,6 +328,49 @@ class WinkSiren(WinkBinarySwitch):
         return self.json_state.get('siren_id', self.name())
 
 
+class WinkKey(WinkDevice):
+    """ represents a wink.py key
+    json_obj holds the json stat at init (if there is a refresh it's updated)
+    it's the native format for this objects methods
+    """
+    UNIT = None
+
+    def __init__(self, device_state_as_json, api_interface, objectprefix="keys"):
+        super(WinkKey, self).__init__(device_state_as_json, api_interface,
+                                      objectprefix=objectprefix)
+        self._capability = "opening"
+
+    def __repr__(self):
+        return "<Wink key name:{name} id:{device}" \
+               " parent id:{parent_id} state:{state}>".format(name=self.name(),
+                                                              device=self.device_id(),
+                                                              parent_id=self.parent_id(),
+                                                              state=self.state())
+
+    def state(self):
+        if 'activity_detected' in self._last_reading:
+            return self._last_reading['activity_detected']
+        return False
+
+    def device_id(self):
+        return self.json_state.get('key_id', self.name())
+
+    def parent_id(self):
+        return self.json_state.get('parent_object_id',
+                                   self.json_state.get('lock_id'))
+
+    def capability(self):
+        """Return opening for all keys."""
+        return self._capability
+
+    @property
+    def available(self):
+        """Keys are virtual therefore they don't have a connection status
+        always return True
+        """
+        return True
+
+
 # pylint-disable: undefined-all-variable
 __all__ = [WinkEggTray.__name__,
            WinkBinarySwitch.__name__,

--- a/src/pywink/devices/types.py
+++ b/src/pywink/devices/types.py
@@ -7,6 +7,7 @@ GARAGE_DOOR = 'garage_door'
 POWER_STRIP = 'powerstrip'
 SHADE = 'shades'
 SIREN = 'siren'
+KEY = 'key'
 
 DEVICE_ID_KEYS = {
     BINARY_SWITCH: 'binary_switch_id',
@@ -17,5 +18,6 @@ DEVICE_ID_KEYS = {
     POWER_STRIP: 'powerstrip_id',
     SENSOR_POD: 'sensor_pod_id',
     SHADE: 'shade_id',
-    SIREN: 'siren_id'
+    SIREN: 'siren_id',
+    KEY: 'key_id'
 }

--- a/src/pywink/test/devices/standard/api_responses/key.json
+++ b/src/pywink/test/devices/standard/api_responses/key.json
@@ -1,0 +1,33 @@
+{
+   "data":{
+      "name":"Key 1",
+      "last_reading":{
+         "slot_id":3,
+         "slot_id_updated_at":1449960280.1004233,
+         "activity_detected":true,
+         "activity_detected_updated_at":1466540653.7276487,
+         "activity_detected_changed_at":1466540653.7276487
+      },
+      "key_id":"257123",
+      "icon_id":null,
+      "verified_at":null,
+      "uuid":"b6d02600-3aed-425c-b6f7-77a4701ce9ea",
+      "parent_object_type":"lock",
+      "parent_object_id":"61123",
+      "desired_state":{
+         "code":null
+      },
+      "subscription":{
+         "pubnub":{
+            "subscribe_key":"sub-c-f7bf7f7e-0542-11e3-a5e8-02e1234567fe",
+            "channel":"d7f700cb00b859eb33bd2fe8344136bc91234560"
+         }
+      }
+   },
+   "errors":[
+
+   ],
+   "pagination":{
+
+   }
+}

--- a/src/pywink/test/devices/standard/init_test.py
+++ b/src/pywink/test/devices/standard/init_test.py
@@ -9,7 +9,7 @@ from pywink.devices.sensors import WinkSensorPod, WinkBrightnessSensor, WinkHumi
      WinkSoundPresenceSensor, WinkVibrationPresenceSensor, WinkTemperatureSensor, \
      _WinkCapabilitySensor
 from pywink.devices.standard import WinkGarageDoor, WinkPowerStripOutlet, WinkSiren, WinkLock, \
-     WinkShade, WinkBinarySwitch, WinkEggTray
+     WinkShade, WinkBinarySwitch, WinkEggTray, WinkKey
 from pywink.devices.types import DEVICE_ID_KEYS
 from pywink.test.devices.standard.api_responses import ApiResponseJSONLoader
 
@@ -381,3 +381,28 @@ class WinkPubnubTests(unittest.TestCase):
             response_dict = json.load(lock_file)
 
         self.assertIsNotNone(self.api_interface.get_subscription_key_from_response_dict(response_dict))
+
+
+
+class WinkKeyTests(unittest.TestCase):
+
+    def setUp(self):
+        super(WinkKeyTests, self).setUp()
+        self.api_interface = mock.MagicMock()
+
+    def test_device_id_should_be_number(self):
+        with open('{}/api_responses/key.json'.format(os.path.dirname(__file__))) as keys_file:
+            response_dict = json.load(keys_file)
+        key = response_dict.get('data')
+
+        wink_key = WinkKey(key, self.api_interface)
+        device_id = wink_key.device_id()
+        self.assertRegex(device_id, "^[0-9]{4,6}$") 
+
+    def test_state_should_be_true_or_false(self):
+        with open('{}/api_responses/key.json'.format(os.path.dirname(__file__))) as keys_file:
+            response_dict = json.load(keys_file)
+        key = response_dict.get('data')
+
+        wink_true_key = WinkKey(key, self.api_interface) 
+        self.assertTrue(wink_true_key.state())

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='python-wink',
-      version='0.7.8',
+      version='0.7.9',
       description='Access Wink devices via the Wink API',
       url='http://github.com/bradsk88/python-wink',
       author='Brad Johnson',


### PR DESCRIPTION
While working on the Garage issue, I discovered another API endpoint /keys. This is how the Wink app is able to do robots based on the user code entered on the Wink lock. This PR will add Wink keys as a "sensor" returning a state of True if the key was recently used. I still need to test to see how long the state stays True. If the state stays True for less then 60 seconds this may be useless unless subscription support is added to the Application using python-wink. 

**Update, it does appear that the state reverts back to false between 30-45 seconds. Maybe there is a way to fix this in code? 

The API returns activity_detected_changed_at as well maybe we could set the state based on activity_detected and activity_detected_changed_at depending on how long it has been since the activity_detected_changed_at was changed, thoughts?

**Update, I will try to get this PR updated once I am back from vacation next week. Now that we have subscription support I believe this should work quite well. Also I noticed that they moved keys into the same API endpoint as all the other devices so this PR should be less complex.
