### PR TITLE
Conserve Brighness on Color Temp Change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.py[cod]
 /test.py
 /.cache
+/src/python_wink.egg-info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 0.7.2
+- Conserving brightness when setting color (temperature, hue sat, etc.)
+
 ## 0.7.1 
 - Exposed bulb color support methods (E.g. supports_hue_saturation())
 

--- a/src/pywink/color.py
+++ b/src/pywink/color.py
@@ -68,7 +68,10 @@ def color_temperature_to_rgb(color_temperature_kelvin):
 # Copyright (c) 2014 Benjamin Knight / MIT License.
 # pylint: disable=bad-builtin
 def color_xy_brightness_to_rgb(vX, vY, brightness):
-    """Convert from XYZ to RGB."""
+    """
+    Convert from XYZ to RGB.
+    :rtype: tuple of int
+    """
     brightness /= 255.
     if brightness == 0:
         return (0, 0, 0)

--- a/src/pywink/test/standard/bulb_test.py
+++ b/src/pywink/test/standard/bulb_test.py
@@ -61,6 +61,76 @@ class BulbSupportsTemperatureTest(unittest.TestCase):
                         msg="Expected temperature to be un-supported")
 
 
+class SetStateTests(unittest.TestCase):
+
+    def setUp(self):
+        super(SetStateTests, self).setUp()
+        self.api_interface = mock.Mock()
+
+    def test_should_send_current_brightness_to_api_if_only_color_temperature_is_provided_and_bulb_only_supports_temperature(self):
+        original_brightness = 0.5
+        bulb = WinkBulb({
+            'brightness': original_brightness,
+            'capabilities': {
+                'color_changeable': True,
+                'fields': [{
+                    'field': 'color_temperature'
+                }]
+            }
+        }, self.api_interface)
+        bulb.set_state(True, color_kelvin=4000)
+        set_state_mock = self.api_interface.set_device_state
+        sent_desired_state = set_state_mock.call_args[0][1]['desired_state']
+        self.assertEquals(original_brightness, sent_desired_state.get('brightness'))
+
+    def test_should_send_color_temperature_to_api_if_color_temp_is_provided_and_bulb_only_supports_temperature(self):
+        bulb = WinkBulb({
+            'capabilities': {
+                'color_changeable': True,
+                'fields': [{
+                    'field': 'color_temperature'
+                }]
+            }
+        }, self.api_interface)
+        color_kelvin = 4000
+        bulb.set_state(True, color_kelvin=color_kelvin)
+        set_state_mock = self.api_interface.set_device_state
+        sent_desired_state = set_state_mock.call_args[0][1]['desired_state']
+        self.assertEquals(color_kelvin, sent_desired_state.get('color_temperature'))
+
+    def test_should_send_current_brightness_to_api_if_only_color_temperature_is_provided_and_bulb_only_supports_hue_sat(
+            self):
+        original_brightness = 0.5
+        bulb = WinkBulb({
+            'brightness': original_brightness,
+            'capabilities': {
+                'color_changeable': True,
+                'fields': [{'field': 'hue'},
+                           {'field': 'saturation'}]
+            }
+        }, self.api_interface)
+        bulb.set_state(True, color_kelvin=4000)
+        set_state_mock = self.api_interface.set_device_state
+        sent_desired_state = set_state_mock.call_args[0][1]['desired_state']
+        self.assertEquals(original_brightness, sent_desired_state.get('brightness'))
+
+    def test_should_send_current_hue_and_saturation_to_api_if_hue_and_sat_are_provided_and_bulb_only_supports_hue_sat(self):
+        bulb = WinkBulb({
+            'capabilities': {
+                'color_changeable': True,
+                'fields': [{'field': 'hue'},
+                           {'field': 'saturation'}]
+            }
+        }, self.api_interface)
+        hue = 0.2
+        saturation = 0.3
+        bulb.set_state(True, color_hue_saturation=[hue, saturation])
+        set_state_mock = self.api_interface.set_device_state
+        sent_desired_state = set_state_mock.call_args[0][1]['desired_state']
+        self.assertEquals(hue, sent_desired_state.get('hue'))
+        self.assertEquals(saturation, sent_desired_state.get('saturation'))
+
+
 class LightTests(unittest.TestCase):
 
     def setUp(self):

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='python-wink',
-      version='0.7.1',
+      version='0.7.2',
       description='Access Wink devices via the Wink API',
       url='http://github.com/bradsk88/python-wink',
       author='Brad Johnson',


### PR DESCRIPTION
Currently, if `color_kelvin`  is supplied to `set_state`
without also supplying a value for `brightness`, the
brightness will be set to 1.0 (full).

This commit fixes that.
