### PR TITLE
Added method to return battery level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 0.7.6
+- Added ability to return the battery level if a device is battery powered
+
 ## 0.7.5 
 - Fixed bug where light bulb states were not updating.
 

--- a/src/pywink/devices/base.py
+++ b/src/pywink/devices/base.py
@@ -37,6 +37,10 @@ class WinkDevice(object):
     def available(self):
         return self._last_reading.get('connection', False)
 
+    @property
+    def battery_level(self):
+        return self._last_reading.get('battery', False)
+
     def _update_state_from_response(self, response_json, require_desired_state_fulfilled=False):
         """
         :param response_json: the json obj returned from query

--- a/src/pywink/devices/base.py
+++ b/src/pywink/devices/base.py
@@ -39,7 +39,7 @@ class WinkDevice(object):
 
     @property
     def battery_level(self):
-        return self._last_reading.get('battery', False)
+        return self._last_reading.get('battery', None)
 
     def _update_state_from_response(self, response_json, require_desired_state_fulfilled=False):
         """

--- a/src/pywink/devices/sensors.py
+++ b/src/pywink/devices/sensors.py
@@ -31,6 +31,13 @@ class _WinkCapabilitySensor(WinkDevice):
             name += " " + self._capability
         return name
 
+    @property
+    def battery_level(self):
+        if not self._last_reading.get('external_power', False):
+            return self._last_reading.get('battery', False)
+        else:
+            return False
+
     def device_id(self):
         root_name = self.json_state.get('sensor_pod_id', self.name())
         return '{}+{}'.format(root_name, self._capability)

--- a/src/pywink/devices/sensors.py
+++ b/src/pywink/devices/sensors.py
@@ -33,7 +33,7 @@ class _WinkCapabilitySensor(WinkDevice):
 
     @property
     def battery_level(self):
-        if not self._last_reading.get('external_power', False):
+        if not self._last_reading.get('external_power', None):
             return self._last_reading.get('battery', None)
         else:
             return None

--- a/src/pywink/devices/sensors.py
+++ b/src/pywink/devices/sensors.py
@@ -34,9 +34,9 @@ class _WinkCapabilitySensor(WinkDevice):
     @property
     def battery_level(self):
         if not self._last_reading.get('external_power', False):
-            return self._last_reading.get('battery', False)
+            return self._last_reading.get('battery', None)
         else:
-            return False
+            return None
 
     def device_id(self):
         root_name = self.json_state.get('sensor_pod_id', self.name())

--- a/src/pywink/test/devices/standard/api_responses/quirky_spotter_2.json
+++ b/src/pywink/test/devices/standard/api_responses/quirky_spotter_2.json
@@ -12,7 +12,7 @@
         "battery_updated_at": 1453188090.419577,
         "brightness": 0,
         "brightness_updated_at": 1453188090.419577,
-        "external_power": true,
+        "external_power": false,
         "external_power_updated_at": 1453188090.419577,
         "humidity": 27,
         "humidity_updated_at": 1453188090.419577,

--- a/src/pywink/test/devices/standard/init_test.py
+++ b/src/pywink/test/devices/standard/init_test.py
@@ -258,6 +258,24 @@ class SensorTests(unittest.TestCase):
             device_id = sensor.device_id()
             self.assertRegex(device_id, "^[0-9]{4,6}")
 
+    def test_battery_level_should_return_none(self):
+        with open('{}/api_responses/quirky_spotter.json'.format(os.path.dirname(__file__))) as spotter_file:
+            response_dict = json.load(spotter_file)
+
+        sensors = get_devices_from_response_dict(response_dict, DEVICE_ID_KEYS[device_types.SENSOR_POD])
+
+        for sensor in sensors:
+            self.assertIsNone(sensor.battery_level)
+
+    def test_battery_level_should_return_float(self):
+        with open('{}/api_responses/quirky_spotter_2.json'.format(os.path.dirname(__file__))) as spotter_file:
+            response_dict = json.load(spotter_file)
+
+        sensors = get_devices_from_response_dict(response_dict, DEVICE_ID_KEYS[device_types.SENSOR_POD])
+
+        for sensor in sensors:
+            self.assertEqual(sensor.battery_level, 0.86)
+
 
 class WinkCapabilitySensorTests(unittest.TestCase):
 
@@ -276,3 +294,4 @@ class WinkCapabilitySensorTests(unittest.TestCase):
         sensor.update_state()
         self.api_interface.get_device_state.assert_called_once_with(sensor, expected_id)
 
+        

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='python-wink',
-      version='0.7.5',
+      version='0.7.6',
       description='Access Wink devices via the Wink API',
       url='http://github.com/bradsk88/python-wink',
       author='Brad Johnson',


### PR DESCRIPTION
@captainnapalm was asking about this yesterday in the python-wink Gitter. It would be use to to have battery level reported into HA so notification could be sent on low battery levels. I would hate to come home to unlock my door and the battery be dead.

Only returning the battery level of the spotter if that device isn't plugged in. 
