### PR TITLE
Add support for Wink Shades

### DIFF
--- a/src/pywink/__init__.py
+++ b/src/pywink/__init__.py
@@ -4,5 +4,4 @@ Top level functions
 # noqa
 from pywink.api import set_bearer_token, set_wink_credentials, get_bulbs, \
     get_eggtrays, get_garage_doors, get_locks, get_powerstrip_outlets, \
-    get_sensors, get_sirens, get_switches, get_devices, is_token_set
-
+    get_sensors, get_shades, get_sirens, get_switches, get_devices, is_token_set

--- a/src/pywink/api.py
+++ b/src/pywink/api.py
@@ -93,6 +93,10 @@ def get_garage_doors():
     return get_devices(device_types.GARAGE_DOOR)
 
 
+def get_shades():
+    return get_devices(device_types.SHADE)
+
+
 def get_powerstrip_outlets():
     return get_devices(device_types.POWER_STRIP)
 

--- a/src/pywink/devices/factory.py
+++ b/src/pywink/devices/factory.py
@@ -1,7 +1,7 @@
 from pywink.devices.base import WinkDevice
 from pywink.devices.sensors import WinkSensorPod
 from pywink.devices.standard import WinkBulb, WinkBinarySwitch, WinkPowerStripOutlet, WinkLock, \
-    WinkEggTray, WinkGarageDoor, WinkSiren
+    WinkEggTray, WinkGarageDoor, WinkShade, WinkSiren
 
 
 def build_device(device_state_as_json, api_interface):
@@ -25,6 +25,8 @@ def build_device(device_state_as_json, api_interface):
         new_object = WinkEggTray(device_state_as_json, api_interface)
     elif "garage_door_id" in device_state_as_json:
         new_object = WinkGarageDoor(device_state_as_json, api_interface)
+    elif "shade_id" in device_state_as_json:
+        new_object = WinkShade(device_state_as_json, api_interface)
     elif "siren_id" in device_state_as_json:
         new_object = WinkSiren(device_state_as_json, api_interface)
 

--- a/src/pywink/devices/types.py
+++ b/src/pywink/devices/types.py
@@ -5,6 +5,7 @@ LOCK = 'lock'
 EGG_TRAY = 'eggtray'
 GARAGE_DOOR = 'garage_door'
 POWER_STRIP = 'powerstrip'
+SHADE = 'shades'
 SIREN = 'siren'
 
 DEVICE_ID_KEYS = {
@@ -15,5 +16,6 @@ DEVICE_ID_KEYS = {
     LOCK: 'lock_id',
     POWER_STRIP: 'powerstrip_id',
     SENSOR_POD: 'sensor_pod_id',
+    SHADE: 'shade_id',
     SIREN: 'siren_id'
 }

--- a/src/pywink/test/devices/standard/api_responses/shade.json
+++ b/src/pywink/test/devices/standard/api_responses/shade.json
@@ -1,0 +1,44 @@
+{
+    "data": [{
+        "uuid": "07b44f75-c7ee-48f1-b43a-f564c15fed1b",
+        "desired_state": {
+            "position": null
+        },
+        "last_reading": {
+            "connection": true,
+            "connection_updated_at": 1463494385.449129,
+            "position": null,
+            "position_updated_at": 1463494385.449129,
+            "desired_position_updated_at": 1463500774.348026,
+            "connection_changed_at": 1457674189.5065048,
+            "desired_position_changed_at": 1463500774.348026
+        },
+        "subscription": {
+            "pubnub": {
+                "subscribe_key": "sub-c-f7bf7f7e-0542-11e3-a5e8-02ee2ddab7fe",
+                "channel": "31be109cff295db0c6d08d411fac0133e46a6138|shade-5650|user-410445"
+            }
+        },
+        "shade_id": "5650",
+        "name": "Left Bed Shade",
+        "locale": "en_us",
+        "units": {},
+        "created_at": 1457674189,
+        "hidden_at": null,
+        "capabilities": {},
+        "triggers": [],
+        "manufacturer_device_model": "somfy_bali",
+        "manufacturer_device_id": null,
+        "device_manufacturer": "somfy",
+        "model_name": "Shade",
+        "upc_id": "81",
+        "upc_code": "SOMFY",
+        "hub_id": "344883",
+        "local_id": "6",
+        "radio_type": "zwave",
+        "lat_lng": [37.813847, -122.277662],
+        "location": "94607"
+    }],
+    "errors": [],
+    "pagination": {}
+}

--- a/src/pywink/test/devices/standard/bulb_test.py
+++ b/src/pywink/test/devices/standard/bulb_test.py
@@ -234,4 +234,3 @@ class LightTests(unittest.TestCase):
         wink_light = WinkBulb(light, self.api_interface)
         device_id = wink_light.device_id()
         self.assertRegex(device_id, "^[0-9]{4,6}$")
-

--- a/src/pywink/test/devices/standard/init_test.py
+++ b/src/pywink/test/devices/standard/init_test.py
@@ -10,7 +10,7 @@ from pywink.devices.sensors import WinkSensorPod, WinkBrightnessSensor, WinkHumi
      WinkSoundPresenceSensor, WinkVibrationPresenceSensor, WinkTemperatureSensor, \
      _WinkCapabilitySensor
 from pywink.devices.standard import WinkBulb, WinkGarageDoor, WinkPowerStripOutlet, WinkSiren, WinkLock, \
-     WinkBinarySwitch, WinkEggTray
+     WinkShade, WinkBinarySwitch, WinkEggTray
 from pywink.devices.types import DEVICE_ID_KEYS
 
 
@@ -65,6 +65,28 @@ class GarageDoorTests(unittest.TestCase):
         garage_door = response_dict.get('data')[0]
         wink_garage_door = WinkGarageDoor(garage_door, self.api_interface)
         device_id = wink_garage_door.device_id()
+        self.assertRegex(device_id, "^[0-9]{4,6}$")
+
+
+class ShadeTests(unittest.TestCase):
+    def setUp(self):
+        super(ShadeTests, self).setUp()
+        self.api_interface = mock.MagicMock()
+
+    def test_should_handle_shade_response(self):
+        with open('{}/api_responses/shade.json'.format(os.path.dirname(__file__))) as shade_file:
+            response_dict = json.load(shade_file)
+        devices = get_devices_from_response_dict(response_dict, DEVICE_ID_KEYS[device_types.SHADE])
+        self.assertEqual(1, len(devices))
+        self.assertIsInstance(devices[0], WinkShade)
+
+    def test_device_id_should_be_number(self):
+        with open('{}/api_responses/shade.json'.format(os.path.dirname(__file__))) as shade_file:
+            response_dict = json.load(shade_file)
+        print(response_dict)
+        shade = response_dict.get('data')[0]
+        wink_shade = WinkShade(shade, self.api_interface)
+        device_id = wink_shade.device_id()
         self.assertRegex(device_id, "^[0-9]{4,6}$")
 
 
@@ -294,4 +316,3 @@ class WinkCapabilitySensorTests(unittest.TestCase):
         sensor.update_state()
         self.api_interface.get_device_state.assert_called_once_with(sensor, expected_id)
 
-        


### PR DESCRIPTION
They're referred to as Blinds, even though the actual content is `shade_id` and model name is `Shade` so I went with Shade, happy to rename if blind is preferred.

Also blinds behave very similarly to garage_doors so this is largely a copy paste. I did remove the `wait_till_desired_reached` method from `WinkShade` since at least the with the Somfy shades (and I'm reasonably sure the Caseta as well) don't provide current_position in the Wink API.

Upstream docs here: http://docs.wink.apiary.io/#reference/device/blind
