### PR TITLE
Fixed powerstrip update state

### DIFF
--- a/src/pywink/devices/standard/__init__.py
+++ b/src/pywink/devices/standard/__init__.py
@@ -126,7 +126,7 @@ class WinkPowerStripOutlet(WinkBinarySwitch):
         response = self.api_interface.get_device_state(self, id_override=self.parent_id())
         power_strip = response.get('data')
         if require_desired_state_fulfilled:
-            if not is_desired_state_reached(power_strip[0]):
+            if not is_desired_state_reached(power_strip[self.index]):
                 return
 
         power_strip_reading = power_strip.get('last_reading')


### PR DESCRIPTION
I haven't tested this, but I believe that the update_state of powerstrips is currently only testing the desired state of index 0 (outlet 0) this replaces the hard-coded 0 with a call to the outlets index method. I will test this when I get home later, but I know I have noticed issues one of my outlets not turning on.
