### PR TITLE
Added unit tests for 3 new devices.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /.cache
 /src/python_wink.egg-info
 /.coverage
+/.idea/*

--- a/src/pywink/api.py
+++ b/src/pywink/api.py
@@ -147,6 +147,8 @@ def get_devices_from_response_dict(response_dict, filter_key):
                 subsensors = _get_subsensors_from_sensor_pod(item, api_interface)
                 if subsensors:
                     devices.extend(subsensors)
+                if len(subsensors) == 1:
+                    continue
 
             devices.append(build_device(item, api_interface))
 
@@ -157,7 +159,7 @@ def _get_subsensors_from_sensor_pod(item, api_interface):
 
     capabilities = [cap['field'] for cap in item.get('capabilities', {}).get('fields', [])]
     if not capabilities:
-        return
+        return []
 
     subsensors = []
 

--- a/src/pywink/test/devices/standard/api_responses/door_sensor_gocontrol.json
+++ b/src/pywink/test/devices/standard/api_responses/door_sensor_gocontrol.json
@@ -1,0 +1,87 @@
+{
+  "data": [
+    {
+      "last_event": {
+        "brightness_occurred_at": null,
+        "loudness_occurred_at": null,
+        "vibration_occurred_at": null
+      },
+      "object_type": "sensor_pod",
+      "object_id": "192444",
+      "uuid": "REMOVED",
+      "icon_id": null,
+      "icon_code": null,
+      "desired_state": {},
+      "last_reading": {
+        "opened": true,
+        "opened_updated_at": 1465222176.887616,
+        "tamper_detected": null,
+        "tamper_detected_updated_at": null,
+        "battery": 1,
+        "battery_updated_at": 1465222176.887616,
+        "tamper_detected_true": null,
+        "tamper_detected_true_updated_at": null,
+        "connection": true,
+        "connection_updated_at": 1465222176.887616,
+        "agent_session_id": null,
+        "agent_session_id_updated_at": null,
+        "connection_changed_at": 1462044709.6055737,
+        "battery_changed_at": 1462048973.2091925,
+        "opened_changed_at": 1465222176.887616
+      },
+      "subscription": {
+        "pubnub": {
+          "subscribe_key": "REMOVED",
+          "channel": "REMOVED"
+        }
+      },
+      "sensor_pod_id": "192444",
+      "name": "Brad Door",
+      "locale": "en_us",
+      "units": {},
+      "created_at": 1462044709,
+      "hidden_at": null,
+      "capabilities": {
+        "fields": [
+          {
+            "type": "boolean",
+            "field": "opened",
+            "mutability": "read-only"
+          },
+          {
+            "type": "boolean",
+            "field": "tamper_detected",
+            "mutability": "read-only"
+          },
+          {
+            "type": "percentage",
+            "field": "battery",
+            "mutability": "read-only"
+          }
+        ],
+        "home_security_device": true
+      },
+      "triggers": [],
+      "manufacturer_device_model": "linear_wadwaz_1",
+      "manufacturer_device_id": null,
+      "device_manufacturer": "linear",
+      "model_name": "Z-Wave Door / Window Transmitter",
+      "upc_id": "189",
+      "upc_code": "9386312509",
+      "gang_id": null,
+      "hub_id": "300039",
+      "local_id": "10",
+      "radio_type": "zwave",
+      "linked_service_id": null,
+      "lat_lng": [
+        0,
+        0
+      ],
+      "location": ""
+    }
+  ],
+  "errors": [],
+  "pagination": {
+    "count": 13
+  }
+}

--- a/src/pywink/test/devices/standard/api_responses/light_switch_ge_jasco_z_wave.json
+++ b/src/pywink/test/devices/standard/api_responses/light_switch_ge_jasco_z_wave.json
@@ -1,0 +1,71 @@
+{
+  "data": [
+    {
+      "object_type": "binary_switch",
+      "object_id": "216721",
+      "uuid": "REMOVED",
+      "icon_id": "52",
+      "icon_code": "binary_switch-light_bulb_dumb",
+      "desired_state": {},
+      "last_reading": {
+        "connection": true,
+        "connection_updated_at": 1465261453.03461,
+        "powered": true,
+        "powered_updated_at": 1465261453.03461,
+        "desired_powered_updated_at": 1465107431.1711504,
+        "connection_changed_at": 1465259877.993167,
+        "powered_changed_at": 1465261453.03461,
+        "desired_powered_changed_at": 1465107431.1711504
+      },
+      "subscription": {
+        "pubnub": {
+          "subscribe_key": "REMOVED",
+          "channel": "REMOVED"
+        }
+      },
+      "binary_switch_id": "216721",
+      "name": "Hallway Switch",
+      "locale": "en_us",
+      "units": {},
+      "created_at": 1464309200,
+      "hidden_at": null,
+      "capabilities": {
+        "fields": [
+          {
+            "type": "boolean",
+            "field": "connection",
+            "mutability": "read-only"
+          },
+          {
+            "type": "boolean",
+            "field": "powered",
+            "mutability": "read-write"
+          }
+        ]
+      },
+      "triggers": [],
+      "manufacturer_device_model": "ge_jasco_binary",
+      "manufacturer_device_id": null,
+      "device_manufacturer": "ge",
+      "model_name": "Binary Switch",
+      "upc_id": "200",
+      "upc_code": "JASCO_ZWAVE_BINARY_POWER",
+      "gang_id": null,
+      "hub_id": "300039",
+      "local_id": "12",
+      "radio_type": "zwave",
+      "linked_service_id": null,
+      "current_budget": null,
+      "lat_lng": [
+        0,
+        0
+      ],
+      "location": "",
+      "order": 0
+    }
+  ],
+  "errors": [],
+  "pagination": {
+    "count": 1
+  }
+}

--- a/src/pywink/test/devices/standard/api_responses/motion_sensor_gocontrol.json
+++ b/src/pywink/test/devices/standard/api_responses/motion_sensor_gocontrol.json
@@ -1,0 +1,89 @@
+{
+  "data": [
+    {
+      "last_event": {
+        "brightness_occurred_at": null,
+        "loudness_occurred_at": null,
+        "vibration_occurred_at": null
+      },
+      "object_type": "sensor_pod",
+      "object_id": "192431",
+      "uuid": "REMOVED",
+      "icon_id": null,
+      "icon_code": null,
+      "desired_state": {},
+      "last_reading": {
+        "motion": true,
+        "motion_updated_at": 1465262763.1264362,
+        "battery": 1,
+        "battery_updated_at": 1465262763.1264362,
+        "tamper_detected": null,
+        "tamper_detected_updated_at": 1462063497.4478416,
+        "motion_true": "N/A",
+        "motion_true_updated_at": null,
+        "tamper_detected_true": null,
+        "tamper_detected_true_updated_at": null,
+        "connection": true,
+        "connection_updated_at": 1465262763.1264362,
+        "agent_session_id": null,
+        "agent_session_id_updated_at": null,
+        "connection_changed_at": 1462043954.4886937,
+        "battery_changed_at": 1462043956.216641,
+        "motion_changed_at": 1465262763.1264362,
+        "motion_true_changed_at": 1465262763.1264362
+      },
+      "subscription": {
+        "pubnub": {
+          "subscribe_key": "REMOVED",
+          "channel": "REMOVED"
+        }
+      },
+      "sensor_pod_id": "192431",
+      "name": "Brad's Room Motion",
+      "locale": "en_us",
+      "units": {},
+      "created_at": 1462043954,
+      "hidden_at": null,
+      "capabilities": {
+        "fields": [
+          {
+            "type": "boolean",
+            "field": "motion",
+            "mutability": "read-only"
+          },
+          {
+            "type": "percentage",
+            "field": "battery",
+            "mutability": "read-only"
+          },
+          {
+            "type": "boolean",
+            "field": "tamper_detected",
+            "mutability": "read-only"
+          }
+        ]
+      },
+      "triggers": [],
+      "manufacturer_device_model": "linear_wapirz_1",
+      "manufacturer_device_id": null,
+      "device_manufacturer": "linear",
+      "model_name": "Z-Wave Passive Infrared (PIR) Sensor",
+      "upc_id": "207",
+      "upc_code": "093863125102",
+      "gang_id": null,
+      "hub_id": "300039",
+      "local_id": "9",
+      "radio_type": "zwave",
+      "linked_service_id": null,
+      "lat_lng": [
+        0,
+        0
+      ],
+      "location": ""
+    }
+  ],
+  "errors": [],
+  "pagination": {
+    "count": 13
+  }
+}

--- a/src/pywink/test/devices/standard/init_test.py
+++ b/src/pywink/test/devices/standard/init_test.py
@@ -1,17 +1,17 @@
 import json
 import mock
 import unittest
-import sys
 import os
 
-from pywink.api import get_devices_from_response_dict, WinkApiInterface
+from pywink.api import get_devices_from_response_dict
 from pywink.devices import types as device_types
 from pywink.devices.sensors import WinkSensorPod, WinkBrightnessSensor, WinkHumiditySensor, \
      WinkSoundPresenceSensor, WinkVibrationPresenceSensor, WinkTemperatureSensor, \
      _WinkCapabilitySensor
-from pywink.devices.standard import WinkBulb, WinkGarageDoor, WinkPowerStripOutlet, WinkSiren, WinkLock, \
+from pywink.devices.standard import WinkGarageDoor, WinkPowerStripOutlet, WinkSiren, WinkLock, \
      WinkShade, WinkBinarySwitch, WinkEggTray
 from pywink.devices.types import DEVICE_ID_KEYS
+from pywink.test.devices.standard.api_responses import ApiResponseJSONLoader
 
 
 class PowerStripTests(unittest.TestCase):
@@ -155,6 +155,12 @@ class BinarySwitchTests(unittest.TestCase):
         device_id = wink_switch.device_id()
         self.assertRegex(device_id, "^[0-9]{4,6}$")
 
+    def test_ge_switch_should_be_identified(self):
+        response = ApiResponseJSONLoader('light_switch_ge_jasco_z_wave.json').load()
+        devices = get_devices_from_response_dict(response, DEVICE_ID_KEYS[device_types.BINARY_SWITCH])
+        self.assertEqual(1, len(devices))
+        self.assertIsInstance(devices[0], WinkBinarySwitch)
+
 
 class BinarySensorTests(unittest.TestCase):
 
@@ -297,6 +303,22 @@ class SensorTests(unittest.TestCase):
 
         for sensor in sensors:
             self.assertEqual(sensor.battery_level, 0.86)
+
+    def test_gocontrol_door_sensor_should_be_identified(self):
+        response = ApiResponseJSONLoader('door_sensor_gocontrol.json').load()
+        devices = get_devices_from_response_dict(response,
+                                                 DEVICE_ID_KEYS[
+                                                     device_types.SENSOR_POD])
+        self.assertEqual(1, len(devices))
+        self.assertIsInstance(devices[0], WinkSensorPod)
+
+    def test_gocontrol_motion_sensor_should_be_identified(self):
+        response = ApiResponseJSONLoader('motion_sensor_gocontrol.json').load()
+        devices = get_devices_from_response_dict(response,
+                                                 DEVICE_ID_KEYS[
+                                                     device_types.SENSOR_POD])
+        self.assertEqual(1, len(devices))
+        self.assertIsInstance(devices[0], WinkSensorPod)
 
 
 class WinkCapabilitySensorTests(unittest.TestCase):


### PR DESCRIPTION
GoControl Motion Sensor
GoControl Door Sensor
GE/Jasco Z Wave Light Switch

Stopped duplicating door switches in `get_devices_from_response_dict`
