### PR TITLE
*.quirky.com SSL cert expired switche to api.wink.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 0.7.10
+- Changed API URL
+
 ## 0.7.9
 - Added Wink keys (Wink Lock user codes)
 

--- a/src/pywink/api.py
+++ b/src/pywink/api.py
@@ -13,7 +13,7 @@ API_HEADERS = {}
 
 class WinkApiInterface(object):
 
-    BASE_URL = "https://winkapi.quirky.com"
+    BASE_URL = "https://api.wink.com"
 
     def set_device_state(self, device, state, id_override=None):
         """

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='python-wink',
-      version='0.7.9',
+      version='0.7.10',
       description='Access Wink devices via the Wink API',
       url='http://github.com/bradsk88/python-wink',
       author='Brad Johnson',


### PR DESCRIPTION
openssl states the cert expired this morning. api.wink.com seems to be working, and is the URL that is listed in the API spec so this should be a pretty safe change.

depth=0 serialNumber = 8Ifj2c1F-lUM/fyH8hU-a4zDiqfW1i9I, OU = GT10739679, OU = See www.rapidssl.com/resources/cps (c)13, OU = Domain Control Validated - RapidSSL(R), CN = *.quirky.com
verify error:num=10:certificate has expired
notAfter=Jul 12 08:03:34 2016 GMT
