### PR TITLE
Fix bulb constructor

### DIFF
--- a/src/pywink/devices/standard/bulb.py
+++ b/src/pywink/devices/standard/bulb.py
@@ -16,8 +16,8 @@ class WinkBulb(WinkBinarySwitch):
     json_state = {}
 
     def __init__(self, device_state_as_json, api_interface):
-        super().__init__(device_state_as_json, api_interface,
-                         objectprefix="light_bulbs")
+        super(WinkBulb, self).__init__(device_state_as_json, api_interface,
+                                       objectprefix="light_bulbs")
 
     def device_id(self):
         return self.json_state.get('light_bulb_id', self.name())


### PR DESCRIPTION
Calling `pywink.get_bulbs()`fails with 

```
     17
     18     def __init__(self, device_state_as_json, api_interface):
---> 19         super().__init__(device_state_as_json, api_interface,
     20                          objectprefix="light_bulbs")
     21

TypeError: super() takes at least 1 argument (0 given)
```
