### PR TITLE
Fix bulb color detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 0.7.13
+- Changed method of detecting WinkBulb capabilities
+
 ## 0.7.12
 - Made WinkBulb constructor python 3-compatible.
 

--- a/src/pywink/devices/standard/bulb.py
+++ b/src/pywink/devices/standard/bulb.py
@@ -124,7 +124,7 @@ class WinkBulb(WinkBinarySwitch):
 
     def supports_rgb(self):
         capabilities = self.json_state.get('capabilities', {})
-        cap_fields = capabilities.get('fields', False)
+        cap_fields = capabilities.get('fields', [])
         if not cap_fields:
             return False
         for field in cap_fields:
@@ -137,7 +137,7 @@ class WinkBulb(WinkBinarySwitch):
 
     def supports_hue_saturation(self):
         capabilities = self.json_state.get('capabilities', {})
-        cap_fields = capabilities.get('fields', False)
+        cap_fields = capabilities.get('fields', [])
         if not cap_fields:
             return False
         for field in cap_fields:
@@ -150,7 +150,7 @@ class WinkBulb(WinkBinarySwitch):
 
     def supports_xy_color(self):
         capabilities = self.json_state.get('capabilities', {})
-        cap_fields = capabilities.get('fields', False)
+        cap_fields = capabilities.get('fields', [])
         if not cap_fields:
             return False
         for field in cap_fields:
@@ -163,7 +163,7 @@ class WinkBulb(WinkBinarySwitch):
 
     def supports_temperature(self):
         capabilities = self.json_state.get('capabilities', {})
-        cap_fields = capabilities.get('fields', False)
+        cap_fields = capabilities.get('fields', [])
         if not cap_fields:
             return False
         for field in cap_fields:

--- a/src/pywink/devices/standard/bulb.py
+++ b/src/pywink/devices/standard/bulb.py
@@ -123,44 +123,55 @@ class WinkBulb(WinkBinarySwitch):
         return {}
 
     def supports_rgb(self):
-        capabilities = self._last_reading.get('capabilities', {})
-        if not capabilities.get('color_changeable', False):
+        capabilities = self.json_state.get('capabilities', {})
+        cap_fields = capabilities.get('fields', False)
+        if not cap_fields:
             return False
-        # cap_fields = capabilities.get('fields', [])
-        # TODO: Do any wink bulbs support RGB specification?
+        for field in cap_fields:
+            _field = field.get('field')
+            if _field == 'color_model':
+                choices = field.get('choices')
+                if "rgb" in choices:
+                    return True
         return False
 
     def supports_hue_saturation(self):
         capabilities = self.json_state.get('capabilities', {})
-        if not capabilities.get('color_changeable', False):
+        cap_fields = capabilities.get('fields', False)
+        if not cap_fields:
             return False
-        cap_fields = capabilities.get('fields', [])
-        supports_hue = False
-        supports_saturation = False
         for field in cap_fields:
             _field = field.get('field')
-            if _field == 'hue':
-                supports_hue = True
-            if _field == 'saturation':
-                supports_saturation = True
-            if supports_hue and supports_saturation:
-                return True
-        if supports_hue and supports_saturation:
-            return True
+            if _field == 'color_model':
+                choices = field.get('choices')
+                if "hsb" in choices:
+                    return True
+        return False
 
     def supports_xy_color(self):
-        # TODO: Do any wink bulbs support XY color?
-        return self.json_state.get("todo", False)
+        capabilities = self.json_state.get('capabilities', {})
+        cap_fields = capabilities.get('fields', False)
+        if not cap_fields:
+            return False
+        for field in cap_fields:
+            _field = field.get('field')
+            if _field == 'color_model':
+                choices = field.get('choices')
+                if "xy" in choices:
+                    return True
+        return False
 
     def supports_temperature(self):
         capabilities = self.json_state.get('capabilities', {})
-        if not capabilities.get('color_changeable', False):
+        cap_fields = capabilities.get('fields', False)
+        if not cap_fields:
             return False
-        cap_fields = capabilities.get('fields', [])
         for field in cap_fields:
             _field = field.get('field')
-            if _field == 'color_temperature':
-                return True
+            if _field == 'color_model':
+                choices = field.get('choices')
+                if "color_temperature" in choices:
+                    return True
         return False
 
     def __repr__(self):

--- a/src/pywink/test/devices/standard/api_responses/rgb_absent.json
+++ b/src/pywink/test/devices/standard/api_responses/rgb_absent.json
@@ -1,0 +1,119 @@
+{
+  "data": [
+    {
+      "uuid": "238539e2-1ad6-44ba-bc53-33c684c36e1d",
+      "desired_state": {
+        "powered": false,
+        "brightness": 1,
+        "color_model": "hsb",
+        "hue": 0.35,
+        "saturation": 1,
+        "color_temperature": 1901
+      },
+      "last_reading": {
+        "connection": true,
+        "connection_updated_at": 1458628651.862995,
+        "powered": false,
+        "powered_updated_at": 1458628651.862995,
+        "brightness": 1,
+        "brightness_updated_at": 1458628651.862995,
+        "color_model": "hsb",
+        "color_model_updated_at": 1458628651.862995,
+        "hue": 0.35,
+        "hue_updated_at": 1458628651.862995,
+        "saturation": 1,
+        "saturation_updated_at": 1458628651.862995,
+        "color_temperature": 1901,
+        "color_temperature_updated_at": 1458628651.862995,
+        "firmware_version": "0.1b02 / 0.3b22",
+        "firmware_version_updated_at": 1458628651.862995,
+        "firmware_date_code": "20150929N****",
+        "firmware_date_code_updated_at": 1458628651.862995,
+        "desired_powered_updated_at": 1458628650.8619466,
+        "desired_brightness_updated_at": 1458628820.0301423,
+        "desired_color_model_updated_at": 1458628820.0301423,
+        "desired_hue_updated_at": 1458628820.0301423,
+        "desired_saturation_updated_at": 1458628820.0301423,
+        "desired_color_temperature_updated_at": 1458628820.0301423,
+        "powered_changed_at": 1458628650.8134031,
+        "brightness_changed_at": 1458122238.7788615,
+        "connection_changed_at": 1457517588.4372394,
+        "desired_powered_changed_at": 1458628650.8619466,
+        "desired_brightness_changed_at": 1458628381.8566465,
+        "firmware_date_code_changed_at": 1457521561.0603704,
+        "color_model_changed_at": 1457521797.6389458,
+        "hue_changed_at": 1457595786.5472758,
+        "saturation_changed_at": 1457595782.71269,
+        "color_temperature_changed_at": 1457521786.911106,
+        "firmware_version_changed_at": 1457521561.0603704,
+        "desired_color_model_changed_at": 1458620834.569744,
+        "desired_hue_changed_at": 1457595786.605935,
+        "desired_saturation_changed_at": 1457595782.8273423,
+        "desired_color_temperature_changed_at": 1457521921.4747667
+      },
+      "light_bulb_id": "1515274",
+      "name": "Bat Signal",
+      "locale": "en_us",
+      "units": {
+      },
+      "created_at": 1457517586,
+      "hidden_at": null,
+      "capabilities": {
+        "fields": [
+          {
+            "field": "connection",
+            "type": "boolean",
+            "mutability": "read-only"
+          },
+          {
+            "field": "powered",
+            "type": "boolean",
+            "mutability": "read-write"
+          },
+          {
+            "field": "brightness",
+            "type": "percentage",
+            "mutability": "read-write"
+          },
+          {
+            "field": "color_model",
+            "type": "string",
+            "choices": [
+              "temperature",
+              "hsb"
+            ]
+          },
+          {
+            "field": "hue",
+            "type": "percentage",
+            "mutability": "read-write"
+          },
+          {
+            "field": "saturation",
+            "type": "percentage",
+            "mutability": "read-write"
+          }
+        ],
+        "color_changeable": true
+      },
+      "triggers": [],
+      "manufacturer_device_model": "sylvania_sylvania_rgbw",
+      "manufacturer_device_id": null,
+      "device_manufacturer": "sylvania",
+      "model_name": "Lightify RGBW Bulb",
+      "upc_id": "509",
+      "upc_code": "4613573703",
+      "gang_id": null,
+      "hub_id": "381678",
+      "local_id": "37",
+      "radio_type": "zigbee",
+      "linked_service_id": null,
+      "lat_lng": [
+        null,
+        null
+      ],
+      "location": "",
+      "order": 0
+    }
+  ]
+}

--- a/src/pywink/test/devices/standard/api_responses/rgb_present.json
+++ b/src/pywink/test/devices/standard/api_responses/rgb_present.json
@@ -1,0 +1,119 @@
+{
+  "data": [
+    {
+      "uuid": "238539e2-1ad6-44ba-bc53-33c684c36e1d",
+      "desired_state": {
+        "powered": false,
+        "brightness": 1,
+        "color_model": "hsb",
+        "hue": 0.35,
+        "saturation": 1,
+        "color_temperature": 1901
+      },
+      "last_reading": {
+        "connection": true,
+        "connection_updated_at": 1458628651.862995,
+        "powered": false,
+        "powered_updated_at": 1458628651.862995,
+        "brightness": 1,
+        "brightness_updated_at": 1458628651.862995,
+        "color_model": "hsb",
+        "color_model_updated_at": 1458628651.862995,
+        "hue": 0.35,
+        "hue_updated_at": 1458628651.862995,
+        "saturation": 1,
+        "saturation_updated_at": 1458628651.862995,
+        "color_temperature": 1901,
+        "color_temperature_updated_at": 1458628651.862995,
+        "firmware_version": "0.1b02 / 0.3b22",
+        "firmware_version_updated_at": 1458628651.862995,
+        "firmware_date_code": "20150929N****",
+        "firmware_date_code_updated_at": 1458628651.862995,
+        "desired_powered_updated_at": 1458628650.8619466,
+        "desired_brightness_updated_at": 1458628820.0301423,
+        "desired_color_model_updated_at": 1458628820.0301423,
+        "desired_hue_updated_at": 1458628820.0301423,
+        "desired_saturation_updated_at": 1458628820.0301423,
+        "desired_color_temperature_updated_at": 1458628820.0301423,
+        "powered_changed_at": 1458628650.8134031,
+        "brightness_changed_at": 1458122238.7788615,
+        "connection_changed_at": 1457517588.4372394,
+        "desired_powered_changed_at": 1458628650.8619466,
+        "desired_brightness_changed_at": 1458628381.8566465,
+        "firmware_date_code_changed_at": 1457521561.0603704,
+        "color_model_changed_at": 1457521797.6389458,
+        "hue_changed_at": 1457595786.5472758,
+        "saturation_changed_at": 1457595782.71269,
+        "color_temperature_changed_at": 1457521786.911106,
+        "firmware_version_changed_at": 1457521561.0603704,
+        "desired_color_model_changed_at": 1458620834.569744,
+        "desired_hue_changed_at": 1457595786.605935,
+        "desired_saturation_changed_at": 1457595782.8273423,
+        "desired_color_temperature_changed_at": 1457521921.4747667
+      },
+      "light_bulb_id": "1515274",
+      "name": "Bat Signal",
+      "locale": "en_us",
+      "units": {
+      },
+      "created_at": 1457517586,
+      "hidden_at": null,
+      "capabilities": {
+        "fields": [
+          {
+            "field": "connection",
+            "type": "boolean",
+            "mutability": "read-only"
+          },
+          {
+            "field": "powered",
+            "type": "boolean",
+            "mutability": "read-write"
+          },
+          {
+            "field": "brightness",
+            "type": "percentage",
+            "mutability": "read-write"
+          },
+          {
+            "field": "color_model",
+            "type": "string",
+            "choices": [
+              "rgb",
+              "hsb"
+            ]
+          },
+          {
+            "field": "hue",
+            "type": "percentage",
+            "mutability": "read-write"
+          },
+          {
+            "field": "saturation",
+            "type": "percentage",
+            "mutability": "read-write"
+          }
+        ],
+        "color_changeable": true
+      },
+      "triggers": [],
+      "manufacturer_device_model": "sylvania_sylvania_rgbw",
+      "manufacturer_device_id": null,
+      "device_manufacturer": "sylvania",
+      "model_name": "Lightify RGBW Bulb",
+      "upc_id": "509",
+      "upc_code": "4613573703",
+      "gang_id": null,
+      "hub_id": "381678",
+      "local_id": "37",
+      "radio_type": "zigbee",
+      "linked_service_id": null,
+      "lat_lng": [
+        null,
+        null
+      ],
+      "location": "",
+      "order": 0
+    }
+  ]
+}

--- a/src/pywink/test/devices/standard/api_responses/temperature_present.json
+++ b/src/pywink/test/devices/standard/api_responses/temperature_present.json
@@ -80,7 +80,8 @@
             "type": "string",
             "choices": [
               "rgb",
-              "hsb"
+              "hsb",
+              "color_temperature"
             ]
           },
           {

--- a/src/pywink/test/devices/standard/api_responses/xy_absent.json
+++ b/src/pywink/test/devices/standard/api_responses/xy_absent.json
@@ -1,0 +1,119 @@
+{
+  "data": [
+    {
+      "uuid": "238539e2-1ad6-44ba-bc53-33c684c36e1d",
+      "desired_state": {
+        "powered": false,
+        "brightness": 1,
+        "color_model": "hsb",
+        "hue": 0.35,
+        "saturation": 1,
+        "color_temperature": 1901
+      },
+      "last_reading": {
+        "connection": true,
+        "connection_updated_at": 1458628651.862995,
+        "powered": false,
+        "powered_updated_at": 1458628651.862995,
+        "brightness": 1,
+        "brightness_updated_at": 1458628651.862995,
+        "color_model": "hsb",
+        "color_model_updated_at": 1458628651.862995,
+        "hue": 0.35,
+        "hue_updated_at": 1458628651.862995,
+        "saturation": 1,
+        "saturation_updated_at": 1458628651.862995,
+        "color_temperature": 1901,
+        "color_temperature_updated_at": 1458628651.862995,
+        "firmware_version": "0.1b02 / 0.3b22",
+        "firmware_version_updated_at": 1458628651.862995,
+        "firmware_date_code": "20150929N****",
+        "firmware_date_code_updated_at": 1458628651.862995,
+        "desired_powered_updated_at": 1458628650.8619466,
+        "desired_brightness_updated_at": 1458628820.0301423,
+        "desired_color_model_updated_at": 1458628820.0301423,
+        "desired_hue_updated_at": 1458628820.0301423,
+        "desired_saturation_updated_at": 1458628820.0301423,
+        "desired_color_temperature_updated_at": 1458628820.0301423,
+        "powered_changed_at": 1458628650.8134031,
+        "brightness_changed_at": 1458122238.7788615,
+        "connection_changed_at": 1457517588.4372394,
+        "desired_powered_changed_at": 1458628650.8619466,
+        "desired_brightness_changed_at": 1458628381.8566465,
+        "firmware_date_code_changed_at": 1457521561.0603704,
+        "color_model_changed_at": 1457521797.6389458,
+        "hue_changed_at": 1457595786.5472758,
+        "saturation_changed_at": 1457595782.71269,
+        "color_temperature_changed_at": 1457521786.911106,
+        "firmware_version_changed_at": 1457521561.0603704,
+        "desired_color_model_changed_at": 1458620834.569744,
+        "desired_hue_changed_at": 1457595786.605935,
+        "desired_saturation_changed_at": 1457595782.8273423,
+        "desired_color_temperature_changed_at": 1457521921.4747667
+      },
+      "light_bulb_id": "1515274",
+      "name": "Bat Signal",
+      "locale": "en_us",
+      "units": {
+      },
+      "created_at": 1457517586,
+      "hidden_at": null,
+      "capabilities": {
+        "fields": [
+          {
+            "field": "connection",
+            "type": "boolean",
+            "mutability": "read-only"
+          },
+          {
+            "field": "powered",
+            "type": "boolean",
+            "mutability": "read-write"
+          },
+          {
+            "field": "brightness",
+            "type": "percentage",
+            "mutability": "read-write"
+          },
+          {
+            "field": "color_model",
+            "type": "string",
+            "choices": [
+              "rgb",
+              "hsb"
+            ]
+          },
+          {
+            "field": "hue",
+            "type": "percentage",
+            "mutability": "read-write"
+          },
+          {
+            "field": "saturation",
+            "type": "percentage",
+            "mutability": "read-write"
+          }
+        ],
+        "color_changeable": true
+      },
+      "triggers": [],
+      "manufacturer_device_model": "sylvania_sylvania_rgbw",
+      "manufacturer_device_id": null,
+      "device_manufacturer": "sylvania",
+      "model_name": "Lightify RGBW Bulb",
+      "upc_id": "509",
+      "upc_code": "4613573703",
+      "gang_id": null,
+      "hub_id": "381678",
+      "local_id": "37",
+      "radio_type": "zigbee",
+      "linked_service_id": null,
+      "lat_lng": [
+        null,
+        null
+      ],
+      "location": "",
+      "order": 0
+    }
+  ]
+}

--- a/src/pywink/test/devices/standard/api_responses/xy_present.json
+++ b/src/pywink/test/devices/standard/api_responses/xy_present.json
@@ -1,0 +1,119 @@
+{
+  "data": [
+    {
+      "uuid": "238539e2-1ad6-44ba-bc53-33c684c36e1d",
+      "desired_state": {
+        "powered": false,
+        "brightness": 1,
+        "color_model": "hsb",
+        "hue": 0.35,
+        "saturation": 1,
+        "color_temperature": 1901
+      },
+      "last_reading": {
+        "connection": true,
+        "connection_updated_at": 1458628651.862995,
+        "powered": false,
+        "powered_updated_at": 1458628651.862995,
+        "brightness": 1,
+        "brightness_updated_at": 1458628651.862995,
+        "color_model": "hsb",
+        "color_model_updated_at": 1458628651.862995,
+        "hue": 0.35,
+        "hue_updated_at": 1458628651.862995,
+        "saturation": 1,
+        "saturation_updated_at": 1458628651.862995,
+        "color_temperature": 1901,
+        "color_temperature_updated_at": 1458628651.862995,
+        "firmware_version": "0.1b02 / 0.3b22",
+        "firmware_version_updated_at": 1458628651.862995,
+        "firmware_date_code": "20150929N****",
+        "firmware_date_code_updated_at": 1458628651.862995,
+        "desired_powered_updated_at": 1458628650.8619466,
+        "desired_brightness_updated_at": 1458628820.0301423,
+        "desired_color_model_updated_at": 1458628820.0301423,
+        "desired_hue_updated_at": 1458628820.0301423,
+        "desired_saturation_updated_at": 1458628820.0301423,
+        "desired_color_temperature_updated_at": 1458628820.0301423,
+        "powered_changed_at": 1458628650.8134031,
+        "brightness_changed_at": 1458122238.7788615,
+        "connection_changed_at": 1457517588.4372394,
+        "desired_powered_changed_at": 1458628650.8619466,
+        "desired_brightness_changed_at": 1458628381.8566465,
+        "firmware_date_code_changed_at": 1457521561.0603704,
+        "color_model_changed_at": 1457521797.6389458,
+        "hue_changed_at": 1457595786.5472758,
+        "saturation_changed_at": 1457595782.71269,
+        "color_temperature_changed_at": 1457521786.911106,
+        "firmware_version_changed_at": 1457521561.0603704,
+        "desired_color_model_changed_at": 1458620834.569744,
+        "desired_hue_changed_at": 1457595786.605935,
+        "desired_saturation_changed_at": 1457595782.8273423,
+        "desired_color_temperature_changed_at": 1457521921.4747667
+      },
+      "light_bulb_id": "1515274",
+      "name": "Bat Signal",
+      "locale": "en_us",
+      "units": {
+      },
+      "created_at": 1457517586,
+      "hidden_at": null,
+      "capabilities": {
+        "fields": [
+          {
+            "field": "connection",
+            "type": "boolean",
+            "mutability": "read-only"
+          },
+          {
+            "field": "powered",
+            "type": "boolean",
+            "mutability": "read-write"
+          },
+          {
+            "field": "brightness",
+            "type": "percentage",
+            "mutability": "read-write"
+          },
+          {
+            "field": "color_model",
+            "type": "string",
+            "choices": [
+              "xy",
+              "hsb"
+            ]
+          },
+          {
+            "field": "hue",
+            "type": "percentage",
+            "mutability": "read-write"
+          },
+          {
+            "field": "saturation",
+            "type": "percentage",
+            "mutability": "read-write"
+          }
+        ],
+        "color_changeable": true
+      },
+      "triggers": [],
+      "manufacturer_device_model": "sylvania_sylvania_rgbw",
+      "manufacturer_device_id": null,
+      "device_manufacturer": "sylvania",
+      "model_name": "Lightify RGBW Bulb",
+      "upc_id": "509",
+      "upc_code": "4613573703",
+      "gang_id": null,
+      "hub_id": "381678",
+      "local_id": "37",
+      "radio_type": "zigbee",
+      "linked_service_id": null,
+      "lat_lng": [
+        null,
+        null
+      ],
+      "location": "",
+      "order": 0
+    }
+  ]
+}

--- a/src/pywink/test/devices/standard/bulb_test.py
+++ b/src/pywink/test/devices/standard/bulb_test.py
@@ -74,10 +74,8 @@ class SetStateTests(unittest.TestCase):
                 'desired_brightness': original_brightness
             },
             'capabilities': {
-                'color_changeable': True,
-                'fields': [{
-                    'field': 'color_temperature'
-                }]
+                'fields': [{'field': 'color_model',
+                           'choices':["color_temperature"]}]
             }
         }, self.api_interface)
         bulb.set_state(True, color_kelvin=4000)
@@ -88,10 +86,8 @@ class SetStateTests(unittest.TestCase):
     def test_should_send_color_temperature_to_api_if_color_temp_is_provided_and_bulb_only_supports_temperature(self):
         bulb = WinkBulb({
             'capabilities': {
-                'color_changeable': True,
-                'fields': [{
-                    'field': 'color_temperature'
-                }]
+                'fields': [{'field': 'color_model',
+                           'choices':["color_temperature"]}]
             }
         }, self.api_interface)
         color_kelvin = 4000
@@ -108,9 +104,8 @@ class SetStateTests(unittest.TestCase):
                 'desired_brightness': original_brightness
             },
             'capabilities': {
-                'color_changeable': True,
-                'fields': [{'field': 'hue'},
-                           {'field': 'saturation'}]
+                'fields': [{'field': 'color_model',
+                           'choices':["hsb"]}]
             }
         }, self.api_interface)
         bulb.set_state(True, color_kelvin=4000)
@@ -121,9 +116,8 @@ class SetStateTests(unittest.TestCase):
     def test_should_send_current_hue_and_saturation_to_api_if_hue_and_sat_are_provided_and_bulb_only_supports_hue_sat(self):
         bulb = WinkBulb({
             'capabilities': {
-                'color_changeable': True,
-                'fields': [{'field': 'hue'},
-                           {'field': 'saturation'}]
+                'fields': [{'field': 'color_model',
+                           'choices':["hsb"]}]
             }
         }, self.api_interface)
         hue = 0.2
@@ -141,9 +135,8 @@ class SetStateTests(unittest.TestCase):
                 'desired_brightness': original_brightness
             },
             'capabilities': {
-                'color_changeable': True,
-                'fields': [{'field': 'hue'},
-                           {'field': 'saturation'}]
+                'fields': [{'field': 'color_model',
+                           'choices':["hsb"]}]
             }
         }, self.api_interface)
         bulb.set_state(True, color_xy=[0.5, 0.5])
@@ -168,16 +161,9 @@ class LightTests(unittest.TestCase):
     @mock.patch('requests.put')
     def test_should_send_correct_color_hsb_values_to_wink_api(self, put_mock):
         bulb = WinkBulb({
-            "capabilities": {
-                "fields": [
-                    {
-                        "field": "hue"
-                    },
-                    {
-                        "field": "saturation"
-                    }
-                ],
-                "color_changeable": True
+            'capabilities': {
+                'fields': [{'field': 'color_model',
+                           'choices':["hsb"]}]
             }
         }, self.api_interface)
         hue = 0.75
@@ -191,13 +177,9 @@ class LightTests(unittest.TestCase):
     @mock.patch('requests.put')
     def test_should_send_correct_color_temperature_values_to_wink_api(self, put_mock):
         bulb = WinkBulb({
-            "capabilities": {
-                "fields": [
-                    {
-                        "field": "color_temperature"
-                    }
-                ],
-                "color_changeable": True
+            'capabilities': {
+                'fields': [{'field': 'color_model',
+                           'choices':["color_temperature"]}]
             }
         }, self.api_interface)
         arbitrary_kelvin_color = 4950
@@ -209,16 +191,9 @@ class LightTests(unittest.TestCase):
     @mock.patch('requests.put')
     def test_should_only_send_color_hsb_if_both_color_hsb_and_color_temperature_are_given(self, put_mock):
         bulb = WinkBulb({
-            "capabilities": {
-                "fields": [
-                    {
-                        "field": "hue"
-                    },
-                    {
-                        "field": "saturation"
-                    }
-                ],
-                "color_changeable": True
+            'capabilities': {
+                'fields': [{'field': 'color_model',
+                           'choices':["hsb"]}]
             }
         }, self.api_interface)
         arbitrary_kelvin_color = 4950

--- a/src/pywink/test/devices/standard/bulb_test.py
+++ b/src/pywink/test/devices/standard/bulb_test.py
@@ -61,6 +61,55 @@ class BulbSupportsTemperatureTest(unittest.TestCase):
                         msg="Expected temperature to be un-supported")
 
 
+class BulbSupportsXYTest(unittest.TestCase):
+
+    def test_should_be_false_if_response_does_not_contain_xy_capabilities(self):
+        with open('{}/api_responses/xy_absent.json'.format(os.path.dirname(__file__))) as light_file:
+            response_dict = json.load(light_file)
+        devices = get_devices_from_response_dict(response_dict, DEVICE_ID_KEYS[device_types.LIGHT_BULB])
+
+        bulb = devices[0]
+        """ :type bulb: pywink.devices.standard.WinkBulb """
+        supports_xy = bulb.supports_xy_color()
+        self.assertFalse(supports_xy,
+                        msg="Expected xy to be un-supported")
+
+    def test_should_be_true_if_response_contains_xy_capabilities(self):
+        with open('{}/api_responses/xy_present.json'.format(os.path.dirname(__file__))) as light_file:
+            response_dict = json.load(light_file)
+        devices = get_devices_from_response_dict(response_dict, DEVICE_ID_KEYS[device_types.LIGHT_BULB])
+
+        bulb = devices[0]
+        """ :type bulb: pywink.devices.standard.WinkBulb """
+        supports_xy = bulb.supports_xy_color()
+        self.assertTrue(supports_xy,
+                        msg="Expected xy to be supported")
+
+
+class BulbSupportsRGBTest(unittest.TestCase):
+
+    def test_should_be_false_if_response_does_not_contain_rgb_capabilities(self):
+        with open('{}/api_responses/rgb_absent.json'.format(os.path.dirname(__file__))) as light_file:
+            response_dict = json.load(light_file)
+        devices = get_devices_from_response_dict(response_dict, DEVICE_ID_KEYS[device_types.LIGHT_BULB])
+
+        bulb = devices[0]
+        """ :type bulb: pywink.devices.standard.WinkBulb """
+        supports_rgb = bulb.supports_rgb()
+        self.assertFalse(supports_rgb,
+                        msg="Expected rgb to be un-supported")
+
+    def test_should_be_true_if_response_contains_rgb_capabilities(self):
+        with open('{}/api_responses/rgb_present.json'.format(os.path.dirname(__file__))) as light_file:
+            response_dict = json.load(light_file)
+        devices = get_devices_from_response_dict(response_dict, DEVICE_ID_KEYS[device_types.LIGHT_BULB])
+
+        bulb = devices[0]
+        """ :type bulb: pywink.devices.standard.WinkBulb """
+        supports_rgb = bulb.supports_rgb()
+        self.assertTrue(supports_rgb,
+                        msg="Expected rgb to be supported")
+
 class SetStateTests(unittest.TestCase):
 
     def setUp(self):

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='python-wink',
-      version='0.7.12',
+      version='0.7.13',
       description='Access Wink devices via the Wink API',
       url='http://github.com/bradsk88/python-wink',
       author='Brad Johnson',


### PR DESCRIPTION
I believe this might fix a few of the open issues. #47 #38  #27 

Based on what I have read in the API and after looking at all of the API responses it appears that if a bulb supports a feature, it will be located in the capabilities>fields>choices array. 

This PR changes the way checking for rgb, xy, hsb, and temperature was done to now look at the choices array. If the string is listed in the array, then True will be returned for the supports_??? method.

I only have one light that uses an enhanced feature (temperature) but I have tested with it, and this is functioning.
