### PR TITLE
Workaround for possible bug in API for color detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 0.7.14
+- If light supports rgb and hsv default to hsv only
+
 ## 0.7.13
 - Changed method of detecting WinkBulb capabilities
 

--- a/src/pywink/devices/standard/bulb.py
+++ b/src/pywink/devices/standard/bulb.py
@@ -123,6 +123,8 @@ class WinkBulb(WinkBinarySwitch):
         return {}
 
     def supports_rgb(self):
+        if self.supports_hue_saturation():
+            return False
         capabilities = self.json_state.get('capabilities', {})
         cap_fields = capabilities.get('fields', [])
         if not cap_fields:

--- a/src/pywink/test/devices/standard/bulb_test.py
+++ b/src/pywink/test/devices/standard/bulb_test.py
@@ -99,7 +99,7 @@ class BulbSupportsRGBTest(unittest.TestCase):
         self.assertFalse(supports_rgb,
                         msg="Expected rgb to be un-supported")
 
-    def test_should_be_true_if_response_contains_rgb_capabilities(self):
+    def test_should_be_false_if_response_contains_rgb_capabilities_and_hsb_capabilities(self):
         with open('{}/api_responses/rgb_present.json'.format(os.path.dirname(__file__))) as light_file:
             response_dict = json.load(light_file)
         devices = get_devices_from_response_dict(response_dict, DEVICE_ID_KEYS[device_types.LIGHT_BULB])
@@ -107,7 +107,7 @@ class BulbSupportsRGBTest(unittest.TestCase):
         bulb = devices[0]
         """ :type bulb: pywink.devices.standard.WinkBulb """
         supports_rgb = bulb.supports_rgb()
-        self.assertTrue(supports_rgb,
+        self.assertFalse(supports_rgb,
                         msg="Expected rgb to be supported")
 
 class SetStateTests(unittest.TestCase):

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='python-wink',
-      version='0.7.13',
+      version='0.7.14',
       description='Access Wink devices via the Wink API',
       url='http://github.com/bradsk88/python-wink',
       author='Brad Johnson',


### PR DESCRIPTION
Fixed required for #27 

The Wink API states the following.

color_model|(string)|**one of**: "xy", "hsb", "color_temperature", or "rgb"

Based on the response from the Osram bulb you would think that it supports setting color via rgb or hsb. I don't see any documentation on how to set via rgb, and I don't see rgb color listed in the response form the Osram bulb. 

So having said that this would be an additional fix for color detection. If a bulb indicates that it supports both rgb and hsb, default to hsb. I will see about reaching out to Wink to have this corrected, or clarified. 

Additional changes to Home-Assistant will still be required for the Osram bulb to work in full color mode. I have it working locally, and will be able to open the Home-Assistant pull request once this is pushed to pypi. 
