### PR TITLE
Return False for RGB support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 0.7.14
+- Return False on RGB support if HSB is also supported.
+
 ## 0.7.13
 - Changed method of detecting WinkBulb capabilities
 

--- a/src/pywink/devices/standard/bulb.py
+++ b/src/pywink/devices/standard/bulb.py
@@ -123,12 +123,15 @@ class WinkBulb(WinkBinarySwitch):
         return {}
 
     def supports_rgb(self):
+        # TODO: Find out if any bulbs actually support RGB
         capabilities = self.json_state.get('capabilities', {})
         cap_fields = capabilities.get('fields', [])
         for field in cap_fields:
             _field = field.get('field')
             if _field == 'color_model':
                 choices = field.get('choices')
+                if "hsb" in choices:
+                    return False
                 if "rgb" in choices:
                     return True
         return False
@@ -199,7 +202,7 @@ def _format_xy(xy):
 def _get_color_as_rgb(hue_sat, kelvin, xy):
     if hue_sat is not None:
         h, s, v = colorsys.hsv_to_rgb(hue_sat[0], hue_sat[1], 1)
-        return tuple(h, s, v)
+        return h, s, v
     if kelvin is not None:
         return color_temperature_to_rgb(kelvin)
     if xy is not None:

--- a/src/pywink/test/devices/standard/bulb_test.py
+++ b/src/pywink/test/devices/standard/bulb_test.py
@@ -99,7 +99,7 @@ class BulbSupportsRGBTest(unittest.TestCase):
         self.assertFalse(supports_rgb,
                         msg="Expected rgb to be un-supported")
 
-    def test_should_be_true_if_response_contains_rgb_capabilities(self):
+    def test_should_be_false_if_response_contains_rgb_capabilities_and_hsb_capabilities(self):
         with open('{}/api_responses/rgb_present.json'.format(os.path.dirname(__file__))) as light_file:
             response_dict = json.load(light_file)
         devices = get_devices_from_response_dict(response_dict, DEVICE_ID_KEYS[device_types.LIGHT_BULB])
@@ -107,7 +107,7 @@ class BulbSupportsRGBTest(unittest.TestCase):
         bulb = devices[0]
         """ :type bulb: pywink.devices.standard.WinkBulb """
         supports_rgb = bulb.supports_rgb()
-        self.assertTrue(supports_rgb,
+        self.assertFalse(supports_rgb,
                         msg="Expected rgb to be supported")
 
 class SetStateTests(unittest.TestCase):

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='python-wink',
-      version='0.7.13',
+      version='0.7.14',
       description='Access Wink devices via the Wink API',
       url='http://github.com/bradsk88/python-wink',
       author='Brad Johnson',


### PR DESCRIPTION
@bradsk88 This is the only way I could return False, and "keep" the supports_rgb code without getting pylint errors. If there is a better solution please let me know. I also fixed the return in _get_color_as_rgb()
