### PR TITLE
[WIP] Wink relay sensors and support for client_id and secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 0.8.0
+- Support for Wink relay sensors and email/password auth
+
 ## 0.7.15
 - Fix for PIR multisensors
 

--- a/src/pywink/__init__.py
+++ b/src/pywink/__init__.py
@@ -2,7 +2,7 @@
 Top level functions
 """
 # noqa
-from pywink.api import set_bearer_token, set_wink_credentials, get_bulbs, \
-    get_eggtrays, get_garage_doors, get_locks, get_powerstrip_outlets, \
-    get_sensors, get_shades, get_sirens, get_switches, get_devices, \
-    is_token_set, get_subscription_key, get_keys, get_piggy_banks
+from pywink.api import set_bearer_token, refresh_access_token, set_wink_credentials, \
+    get_bulbs, get_eggtrays, get_garage_doors, get_locks, \
+    get_powerstrip_outlets, get_sensors, get_shades, get_sirens, get_switches, \
+    get_devices, is_token_set, get_subscription_key, get_keys, get_piggy_banks

--- a/src/pywink/__init__.py
+++ b/src/pywink/__init__.py
@@ -2,7 +2,8 @@
 Top level functions
 """
 # noqa
-from pywink.api import set_bearer_token, refresh_access_token, set_wink_credentials, \
-    get_bulbs, get_eggtrays, get_garage_doors, get_locks, \
-    get_powerstrip_outlets, get_sensors, get_shades, get_sirens, get_switches, \
-    get_devices, is_token_set, get_subscription_key, get_keys, get_piggy_banks
+from pywink.api import set_bearer_token, refresh_access_token, \
+    set_wink_credentials, set_user_agent, get_bulbs, get_eggtrays, \
+    get_garage_doors, get_locks, get_powerstrip_outlets, get_sensors, \
+    get_shades, get_sirens, get_switches, get_devices, is_token_set, \
+    get_subscription_key, get_keys, get_piggy_banks

--- a/src/pywink/api.py
+++ b/src/pywink/api.py
@@ -7,7 +7,8 @@ from pywink.devices.factory import build_device
 from pywink.devices.standard import WinkPorkfolioNose
 from pywink.devices.sensors import WinkSensorPod, WinkHumiditySensor, WinkBrightnessSensor, WinkSoundPresenceSensor, \
     WinkTemperatureSensor, WinkVibrationPresenceSensor, \
-    WinkLiquidPresenceSensor, WinkCurrencySensor, WinkMotionSensor
+    WinkLiquidPresenceSensor, WinkCurrencySensor, WinkMotionSensor, \
+    WinkPresenceSensor, WinkProximitySensor
 from pywink.devices.types import DEVICE_ID_KEYS
 
 API_HEADERS = {}
@@ -44,13 +45,15 @@ class WinkApiInterface(object):
         return arequest.json()
 
 
-def set_bearer_token(token):
+def set_bearer_token(token, user_agent=None):
     global API_HEADERS
 
     API_HEADERS = {
         "Content-Type": "application/json",
         "Authorization": "Bearer {}".format(token)
     }
+    if user_agent:
+        API_HEADERS["User-Agent"] = user_agent
 
 
 def set_wink_credentials(client_id, client_secret, refresh_token):
@@ -190,6 +193,7 @@ def get_devices_from_response_dict(response_dict, filter_key):
 def _get_subsensors_from_sensor_pod(item, api_interface):
 
     capabilities = [cap['field'] for cap in item.get('capabilities', {}).get('fields', [])]
+    capabilities.extend([cap['field'] for cap in item.get('capabilities', {}).get('sensor_types', [])])
 
     if not capabilities:
         return []
@@ -216,6 +220,12 @@ def _get_subsensors_from_sensor_pod(item, api_interface):
 
     if WinkMotionSensor.CAPABILITY in capabilities:
         subsensors.append(WinkMotionSensor(item, api_interface))
+
+    if WinkPresenceSensor.CAPABILITY in capabilities:
+        subsensors.append(WinkPresenceSensor(item, api_interface))
+
+    if WinkProximitySensor.CAPABILITY in capabilities:
+        subsensors.append(WinkProximitySensor(item, api_interface))
 
     if WinkSensorPod.CAPABILITY in capabilities:
         subsensors.append(WinkSensorPod(item, api_interface))

--- a/src/pywink/api.py
+++ b/src/pywink/api.py
@@ -36,7 +36,7 @@ class WinkApiInterface(object):
         arequest = requests.put(url_string,
                                 data=json.dumps(state),
                                 headers=API_HEADERS)
-        if arequest.status == 401:
+        if arequest.status_code == 401:
             new_token = refresh_access_token()
             if new_token:
                 arequest = requests.put(url_string,

--- a/src/pywink/api.py
+++ b/src/pywink/api.py
@@ -12,6 +12,10 @@ from pywink.devices.sensors import WinkSensorPod, WinkHumiditySensor, WinkBright
 from pywink.devices.types import DEVICE_ID_KEYS
 
 API_HEADERS = {}
+CLIENT_ID = None
+CLIENT_SECRET = None
+REFRESH_TOKEN = None
+USER_AGENT = None
 
 
 class WinkApiInterface(object):
@@ -32,6 +36,14 @@ class WinkApiInterface(object):
         arequest = requests.put(url_string,
                                 data=json.dumps(state),
                                 headers=API_HEADERS)
+        if arequest.status == 401:
+            new_token = refresh_access_token()
+            if new_token:
+                arequest = requests.put(url_string,
+                                        data=json.dumps(state),
+                                        headers=API_HEADERS)
+            else:
+                raise WinkAPIException("Failed to refresh access token.")
         return arequest.json()
 
     def get_device_state(self, device, id_override=None):
@@ -45,23 +57,35 @@ class WinkApiInterface(object):
         return arequest.json()
 
 
-def set_bearer_token(token, user_agent=None):
+def set_bearer_token(token):
     global API_HEADERS
 
     API_HEADERS = {
         "Content-Type": "application/json",
         "Authorization": "Bearer {}".format(token)
     }
-    if user_agent:
-        API_HEADERS["User-Agent"] = user_agent
+    if USER_AGENT:
+        API_HEADERS["User-Agent"] = USER_AGENT
 
 
-def set_wink_credentials(client_id, client_secret, refresh_token):
+def set_user_agent(user_agent):
+    global USER_AGENT
+
+    USER_AGENT = user_agent
+
+
+def set_wink_credentials(email, password, client_id, client_secret):
+    global CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN
+
+    CLIENT_ID = client_id
+    CLIENT_SECRET = client_secret
+
     data = {
         "client_id": client_id,
         "client_secret": client_secret,
-        "grant_type": "refresh_token",
-        "refresh_token": refresh_token
+        "grant_type": "password",
+        "email": email,
+        "password": password
     }
     headers = {
         'Content-Type': 'application/json'
@@ -71,8 +95,30 @@ def set_wink_credentials(client_id, client_secret, refresh_token):
                              headers=headers)
     response_json = response.json()
     access_token = response_json.get('access_token')
+    REFRESH_TOKEN = response_json.get('refresh_token')
     set_bearer_token(access_token)
-    return access_token
+
+
+def refresh_access_token():
+    if CLIENT_ID and CLIENT_SECRET and REFRESH_TOKEN:
+        data = {
+            "client_id": CLIENT_ID,
+            "client_secret": CLIENT_SECRET,
+            "grant_type": "refresh_token",
+            "refresh_token": REFRESH_TOKEN
+        }
+        headers = {
+            'Content-Type': 'application/json'
+        }
+        response = requests.post('{}/oauth2/token'.format(WinkApiInterface.BASE_URL),
+                                 data=json.dumps(data),
+                                 headers=headers)
+        response_json = response.json()
+        access_token = response_json.get('access_token')
+        set_bearer_token(access_token)
+        return access_token
+    else:
+        return None
 
 
 def get_bulbs():

--- a/src/pywink/devices/sensors.py
+++ b/src/pywink/devices/sensors.py
@@ -91,7 +91,11 @@ class WinkHumiditySensor(_WinkCapabilitySensor):
         :return: The relative humidity detected by the sensor (0% to 100%)
         :rtype: int
         """
-        return self.last_reading()
+        # Relay returns humidity as a decimal
+        if self.last_reading() < 1.0:
+            return int(round(self.last_reading() * 100))
+        else:
+            return self.last_reading()
 
     def pubnub_update(self, json_response):
         # Pubnub returns the humidity as a decimal

--- a/src/pywink/devices/sensors.py
+++ b/src/pywink/devices/sensors.py
@@ -255,6 +255,15 @@ class WinkCurrencySensor(_WinkCapabilitySensor):
                                                  self.CAPABILITY,
                                                  self.UNIT)
 
+    @property
+    def available(self):
+        """
+        connection variable isn't stable.
+        Porkfolio can be offline, but updates will continue to occur.
+        always returning True to avoid this issue.
+        """
+        return True
+
     def device_id(self):
         root_name = self.json_state.get('piggy_bank_id', self.name())
         return '{}+{}'.format(root_name, self._capability)

--- a/src/pywink/devices/sensors.py
+++ b/src/pywink/devices/sensors.py
@@ -209,6 +209,42 @@ class WinkMotionSensor(_WinkCapabilitySensor):
         return self.last_reading()
 
 
+class WinkPresenceSensor(_WinkCapabilitySensor):
+
+    CAPABILITY = 'presence'
+    UNIT = None
+
+    def __init__(self, device_state_as_json, api_interface):
+        super(WinkPresenceSensor, self).__init__(device_state_as_json, api_interface,
+                                                 self.CAPABILITY,
+                                                 self.UNIT)
+
+    def presence_boolean(self):
+        """
+        :return: Returns True if presence is detected.
+        :rtype: bool
+        """
+        return self.last_reading()
+
+
+class WinkProximitySensor(_WinkCapabilitySensor):
+
+    CAPABILITY = 'proximity'
+    UNIT = None
+
+    def __init__(self, device_state_as_json, api_interface):
+        super(WinkProximitySensor, self).__init__(device_state_as_json, api_interface,
+                                                  self.CAPABILITY,
+                                                  self.UNIT)
+
+    def proximity_float(self):
+        """
+        :return: A float indicating the proximity.
+        :rtype: float
+        """
+        return self.last_reading()
+
+
 class WinkCurrencySensor(_WinkCapabilitySensor):
 
     CAPABILITY = 'balance'

--- a/src/pywink/test/devices/standard/api_responses/wink_relay_sensor.json
+++ b/src/pywink/test/devices/standard/api_responses/wink_relay_sensor.json
@@ -1,0 +1,107 @@
+{  
+   "data":[  
+      {  
+         "hidden_at":null,
+         "manufacturer_device_model":"wink_relay_sensor",
+         "object_id":"231234",
+         "radio_type":"project_one",
+         "manufacturer_device_id":null,
+         "locale":"en_us",
+         "upc_id":"188",
+         "location":"",
+         "gang_id":"40123",
+         "desired_state":{  
+
+         },
+         "subscription":{  
+            "pubnub":{  
+               "subscribe_key":"sub-c-f7bf7f7e-0542-11e323456-12142ddab7fe",
+               "channel":"a82816f0ddb9fa5448c5cb471d21716564871164|sensor_pod-123787|user-220271"
+            }
+         },
+         "created_at":1468460695,
+         "lat_lng":[  
+            null,
+            null
+         ],
+         "triggers":[  
+
+         ],
+         "units":{  
+
+         },
+         "model_name":"Wink Relay Sensor",
+         "name":"Great Room Relay",
+         "device_manufacturer":"wink",
+         "icon_id":null,
+         "last_event":{  
+            "vibration_occurred_at":null,
+            "loudness_occurred_at":null,
+            "brightness_occurred_at":null
+         },
+         "local_id":"3",
+         "capabilities":{  
+            "desired_state_fields":[  
+
+            ],
+            "sensor_types":[  
+               {  
+                  "mutability":"read-only",
+                  "field":"temperature",
+                  "attribute_id":1,
+                  "type":"float"
+               },
+               {  
+                  "mutability":"read-only",
+                  "field":"humidity",
+                  "attribute_id":2,
+                  "type":"percentage"
+               },
+               {  
+                  "mutability":"read-only",
+                  "field":"presence",
+                  "attribute_id":3,
+                  "type":"boolean"
+               },
+               {  
+                  "mutability":"read-only",
+                  "field":"proximity",
+                  "attribute_id":4,
+                  "type":"float"
+               }
+            ]
+         },
+         "sensor_pod_id":"212345",
+         "last_reading":{  
+            "temperature_updated_at":1474295085.8156993,
+            "agent_session_id_updated_at":null,
+            "presence":false,
+            "agent_session_id":null,
+            "temperature":19.87,
+            "humidity_changed_at":1474295085.8156993,
+            "proximity":2512.0,
+            "presence_updated_at":1474295085.8156993,
+            "proximity_updated_at":1474295085.8156993,
+            "proximity_changed_at":1474295085.8156993,
+            "presence_changed_at":1474281889.6097996,
+            "connection":true,
+            "humidity":0.69,
+            "connection_updated_at":1474295085.8156993,
+            "temperature_changed_at":1474295085.8156993,
+            "humidity_updated_at":1474295085.8156993
+         },
+         "uuid":"9bb49bfe-0d6a-4e9b-9896-f33c37ec969b",
+         "icon_code":null,
+         "object_type":"sensor_pod",
+         "upc_code":"wink_p1_sensor",
+         "linked_service_id":null,
+         "hub_id":"451234"
+      }
+   ],
+   "errors":[  
+
+   ],
+   "pagination":{  
+      "count":13
+   }
+}

--- a/src/pywink/test/devices/standard/init_test.py
+++ b/src/pywink/test/devices/standard/init_test.py
@@ -3,11 +3,12 @@ import mock
 import unittest
 import os
 
-from pywink.api import get_devices_from_response_dict
+from pywink.api import get_devices_from_response_dict, set_bearer_token
 from pywink.devices import types as device_types
 from pywink.devices.sensors import WinkSensorPod, WinkBrightnessSensor, WinkHumiditySensor, \
      WinkSoundPresenceSensor, WinkVibrationPresenceSensor, WinkTemperatureSensor, \
-     _WinkCapabilitySensor, WinkLiquidPresenceSensor, WinkCurrencySensor, WinkMotionSensor
+     _WinkCapabilitySensor, WinkLiquidPresenceSensor, WinkCurrencySensor, WinkMotionSensor, \
+     WinkProximitySensor, WinkPresenceSensor
 from pywink.devices.standard import WinkGarageDoor, WinkPowerStripOutlet, WinkSiren, WinkLock, \
      WinkShade, WinkBinarySwitch, WinkEggTray, WinkKey, WinkPorkfolioNose
 from pywink.devices.types import DEVICE_ID_KEYS
@@ -441,3 +442,20 @@ class PorkfolioTests(unittest.TestCase):
 
         device_id = devices[1].device_id()
         self.assertRegex(device_id, "^[0-9]{4,6}")
+
+class RelaySensorTests(unittest.TestCase):
+
+    def setUp(self):
+        super(RelaySensorTests, self).setUp()
+        self.api_interface = mock.MagicMock()
+
+    def test_should_handle_relay_response(self):
+        with open('{}/api_responses/wink_relay_sensor.json'.format(os.path.dirname(__file__))) as relay_file:
+            response_dict = json.load(relay_file)
+        devices = get_devices_from_response_dict(response_dict, DEVICE_ID_KEYS[device_types.SENSOR_POD])
+        self.assertEqual(4, len(devices))
+        self.assertIsInstance(devices[0], WinkHumiditySensor)
+        self.assertIsInstance(devices[1], WinkTemperatureSensor)
+        self.assertIsInstance(devices[2], WinkPresenceSensor)
+        self.assertIsInstance(devices[3], WinkProximitySensor)
+

--- a/src/pywink/test/devices/standard/init_test.py
+++ b/src/pywink/test/devices/standard/init_test.py
@@ -459,3 +459,9 @@ class RelaySensorTests(unittest.TestCase):
         self.assertIsInstance(devices[2], WinkPresenceSensor)
         self.assertIsInstance(devices[3], WinkProximitySensor)
 
+    def test_should_convert_humidity_to_percentage(self):
+        with open('{}/api_responses/wink_relay_sensor.json'.format(os.path.dirname(__file__))) as relay_file:
+            response_dict = json.load(relay_file)
+        devices = get_devices_from_response_dict(response_dict, DEVICE_ID_KEYS[device_types.SENSOR_POD])
+        self.assertEqual(devices[0].humidity_percentage(), 69)
+

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='python-wink',
-      version='0.7.15',
+      version='0.8.0',
       description='Access Wink devices via the Wink API',
       url='http://github.com/bradsk88/python-wink',
       author='Brad Johnson',


### PR DESCRIPTION
The Wink relay has four sensors built in. Temperature, Humidity, Presence, and Proximity. Unfortunately these sensors aren't returned in the call to /usres/me/wink_devices unless a specific user-agent is provided in the API call. The API is looking for this format "Manufacturer/python-wink WinkiOS/4" or "Manufacturer/python-wink WinkAndroid/4" @xrolfex and I tested this and it looks like they are expecting the Manufacturer/ but the value doesn't matter, they are expecting either WinkAndroid/ or WinkiOS/ with at least a 4 after it. 

This PR adds a function to set the passed user-agent, defaulted to no user-agent. This will allow setting it if the user has a relay. The plan is to add support in Home-Assistant for a config variable. This will also allow the user to change it if the format expectation from the API changes.

This also adds support for obtaining the API access token with user provided client_id, client_secret, email, and password. If the user provides these, it will also perform automatic token refreshing if the API returns a 401. This along with a Home-Assistant update will allow users with their own client_id and client_secret to not have to update their tokens.

This is going to need some testing, which will require work in Home-Assistant to make that easier. 

**Note: The proximity sensor for the relay returns a float, I have no idea what the unit is or the range on the number. Also not sure what the presence sensor detects? Possibly the presence of someone standing in front of the device? I will work with @xrolfex to figure that out.
