### PR TITLE
Support for smoke and co detectors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 0.8.1
+- Support for Wink Smoke and CO detectors
+
 ## 0.8.0
 - Support for Wink relay sensors and email/password auth
 

--- a/src/pywink/__init__.py
+++ b/src/pywink/__init__.py
@@ -6,4 +6,5 @@ from pywink.api import set_bearer_token, refresh_access_token, \
     set_wink_credentials, set_user_agent, get_bulbs, get_eggtrays, \
     get_garage_doors, get_locks, get_powerstrip_outlets, get_sensors, \
     get_shades, get_sirens, get_switches, get_devices, is_token_set, \
-    get_subscription_key, get_keys, get_piggy_banks
+    get_subscription_key, get_keys, get_piggy_banks, \
+    get_smoke_and_co_detectors

--- a/src/pywink/api.py
+++ b/src/pywink/api.py
@@ -8,7 +8,8 @@ from pywink.devices.standard import WinkPorkfolioNose
 from pywink.devices.sensors import WinkSensorPod, WinkHumiditySensor, WinkBrightnessSensor, WinkSoundPresenceSensor, \
     WinkTemperatureSensor, WinkVibrationPresenceSensor, \
     WinkLiquidPresenceSensor, WinkCurrencySensor, WinkMotionSensor, \
-    WinkPresenceSensor, WinkProximitySensor
+    WinkPresenceSensor, WinkProximitySensor, WinkSmokeDetector, \
+    WinkCoDetector
 from pywink.devices.types import DEVICE_ID_KEYS
 
 API_HEADERS = {}
@@ -165,6 +166,10 @@ def get_piggy_banks():
     return get_devices(device_types.PIGGY_BANK)
 
 
+def get_smoke_and_co_detectors():
+    return get_devices(device_types.SMOKE_DETECTOR)
+
+
 def get_subscription_key():
     response_dict = wink_api_fetch()
     first_device = response_dict.get('data')[0]
@@ -231,6 +236,10 @@ def get_devices_from_response_dict(response_dict, filter_key):
                 devices.extend(__get_devices_from_piggy_bank(item, api_interface))
                 continue  # Don't capture the porkfolio itself as a device
 
+            if key == "smoke_detector_id":
+                devices.extend(__get_subsensors_from_smoke_detector(item, api_interface))
+                continue  # Don't capture the base device
+
             devices.append(build_device(item, api_interface))
 
     return devices
@@ -293,6 +302,13 @@ def __get_devices_from_piggy_bank(item, api_interface):
     subdevices.append(WinkCurrencySensor(item, api_interface))
     subdevices.append(WinkPorkfolioNose(item, api_interface))
     return subdevices
+
+
+def __get_subsensors_from_smoke_detector(item, api_interface):
+    subsensors = []
+    subsensors.append(WinkSmokeDetector(item, api_interface))
+    subsensors.append(WinkCoDetector(item, api_interface))
+    return subsensors
 
 
 def __device_is_visible(item, key):

--- a/src/pywink/devices/sensors.py
+++ b/src/pywink/devices/sensors.py
@@ -39,7 +39,9 @@ class _WinkCapabilitySensor(WinkDevice):
             return None
 
     def device_id(self):
-        root_name = self.json_state.get('sensor_pod_id', self.name())
+        root_name = self.json_state.get('sensor_pod_id', None)
+        if root_name is None:
+            root_name = self.json_state.get('smoke_detector_id', self.name())
         return '{}+{}'.format(root_name, self._capability)
 
     def update_state(self, require_desired_state_fulfilled=False):
@@ -276,5 +278,41 @@ class WinkCurrencySensor(_WinkCapabilitySensor):
         """
         :return: Returns the balance in cents.
         :rtype: int
+        """
+        return self.last_reading()
+
+
+class WinkSmokeDetector(_WinkCapabilitySensor):
+
+    CAPABILITY = 'smoke_detected'
+    UNIT = None
+
+    def __init__(self, device_state_as_json, api_interface):
+        super(WinkSmokeDetector, self).__init__(device_state_as_json, api_interface,
+                                                self.CAPABILITY,
+                                                self.UNIT)
+
+    def smoke_detected_boolean(self):
+        """
+        :return: Returns True if smoke is detected.
+        :rtype: bool
+        """
+        return self.last_reading()
+
+
+class WinkCoDetector(_WinkCapabilitySensor):
+
+    CAPABILITY = 'co_detected'
+    UNIT = None
+
+    def __init__(self, device_state_as_json, api_interface):
+        super(WinkCoDetector, self).__init__(device_state_as_json, api_interface,
+                                             self.CAPABILITY,
+                                             self.UNIT)
+
+    def co_detected_boolean(self):
+        """
+        :return: Returns True if CO is detected.
+        :rtype: bool
         """
         return self.last_reading()

--- a/src/pywink/devices/types.py
+++ b/src/pywink/devices/types.py
@@ -9,6 +9,7 @@ SHADE = 'shades'
 SIREN = 'siren'
 KEY = 'key'
 PIGGY_BANK = 'piggybank'
+SMOKE_DETECTOR = 'smoke_detector'
 
 DEVICE_ID_KEYS = {
     BINARY_SWITCH: 'binary_switch_id',
@@ -21,5 +22,6 @@ DEVICE_ID_KEYS = {
     SHADE: 'shade_id',
     SIREN: 'siren_id',
     KEY: 'key_id',
-    PIGGY_BANK: 'piggy_bank_id'
+    PIGGY_BANK: 'piggy_bank_id',
+    SMOKE_DETECTOR: 'smoke_detector_id'
 }

--- a/src/pywink/test/devices/standard/api_responses/smoke_detector.json
+++ b/src/pywink/test/devices/standard/api_responses/smoke_detector.json
@@ -1,0 +1,61 @@
+{  
+   "data":[  
+      {  
+         "object_type":"smoke_detector",
+         "object_id":"12345",
+         "uuid":"54feac93-327e-4f04-a8ba-500c88e95245",
+         "icon_id":null,
+         "icon_code":null,
+         "last_reading":{  
+            "connection":true,
+            "connection_updated_at":1462586187.9383092,
+            "battery":0.9,
+            "battery_updated_at":1462586188.4449866,
+            "co_detected":true,
+            "co_detected_updated_at":1462586188.4449866,
+            "smoke_detected":false,
+            "smoke_detected_updated_at":1471015253.2221863,
+            "test_activated":false,
+            "test_activated_updated_at":1462997176.8458738
+         },
+         "subscription":{  
+            "pubnub":{  
+               "subscribe_key":"REMOVED",
+               "channel":"Removed|smoke_detector-REMOVED|user-REMOVED"
+            }
+         },
+         "smoke_detector_id":"12345",
+         "name":"Hallway Smoke Detector",
+         "locale":"en_us",
+         "units":{  
+
+         },
+         "created_at":1462586187,
+         "hidden_at":null,
+         "capabilities":{  
+
+         },
+         "manufacturer_device_model":"kidde_smoke_alarm",
+         "manufacturer_device_id":null,
+         "device_manufacturer":"kidde",
+         "model_name":"Smoke Alarm",
+         "upc_id":"524",
+         "upc_code":"kidde_smoke_alarm",
+         "hub_id":"REMOVED",
+         "local_id":null,
+         "radio_type":"kidde",
+         "linked_service_id":null,
+         "lat_lng":[  
+            39.00000,
+            -77.00000
+         ],
+         "location":"REMOVED"
+      }
+   ],
+   "errors":[  
+
+   ],
+   "pagination":{  
+      "count":13
+   }
+}

--- a/src/pywink/test/devices/standard/init_test.py
+++ b/src/pywink/test/devices/standard/init_test.py
@@ -8,7 +8,7 @@ from pywink.devices import types as device_types
 from pywink.devices.sensors import WinkSensorPod, WinkBrightnessSensor, WinkHumiditySensor, \
      WinkSoundPresenceSensor, WinkVibrationPresenceSensor, WinkTemperatureSensor, \
      _WinkCapabilitySensor, WinkLiquidPresenceSensor, WinkCurrencySensor, WinkMotionSensor, \
-     WinkProximitySensor, WinkPresenceSensor
+     WinkProximitySensor, WinkPresenceSensor, WinkSmokeDetector, WinkCoDetector
 from pywink.devices.standard import WinkGarageDoor, WinkPowerStripOutlet, WinkSiren, WinkLock, \
      WinkShade, WinkBinarySwitch, WinkEggTray, WinkKey, WinkPorkfolioNose
 from pywink.devices.types import DEVICE_ID_KEYS
@@ -464,4 +464,30 @@ class RelaySensorTests(unittest.TestCase):
             response_dict = json.load(relay_file)
         devices = get_devices_from_response_dict(response_dict, DEVICE_ID_KEYS[device_types.SENSOR_POD])
         self.assertEqual(devices[0].humidity_percentage(), 69)
+
+
+class SmokeDetectorTests(unittest.TestCase):
+
+    def setUp(self):
+        super(SmokeDetectorTests, self).setUp()
+        self.api_interface = mock.MagicMock()
+
+    def test_should_handle_smoke_detector_response(self):
+        with open('{}/api_responses/smoke_detector.json'.format(os.path.dirname(__file__))) as smoke_detector_file:
+            response_dict = json.load(smoke_detector_file)
+        devices = get_devices_from_response_dict(response_dict, DEVICE_ID_KEYS[device_types.SMOKE_DETECTOR])
+        self.assertEqual(2, len(devices))
+        smoke = devices[0]
+        co = devices[1]
+        self.assertIsInstance(smoke, WinkSmokeDetector)
+        self.assertIsInstance(co, WinkCoDetector)
+        self.assertFalse(smoke.smoke_detected_boolean())
+        self.assertTrue(co.co_detected_boolean())
+
+    def test_device_id_should_be_number(self):
+        with open('{}/api_responses/smoke_detector.json'.format(os.path.dirname(__file__))) as smoke_detector_file:
+            response_dict = json.load(smoke_detector_file)
+        devices = get_devices_from_response_dict(response_dict, DEVICE_ID_KEYS[device_types.SMOKE_DETECTOR])
+        device_id = devices[0].device_id()
+        self.assertRegex(device_id, "^[0-9]{4,6}")
 

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='python-wink',
-      version='0.8.0',
+      version='0.8.1',
       description='Access Wink devices via the Wink API',
       url='http://github.com/bradsk88/python-wink',
       author='Brad Johnson',


### PR DESCRIPTION
@rbflurry I think this should do it, can you test? Download my fork, checkout the `smoke_and_co` branch and run the below script from inside of /python-wink/src/ Add your access token of course. You should get output for two sensors, CO and Smoke.

``` python
#!/usr/bin/python3

import pywink
import sys
import json

pywink.set_bearer_token('PUT YOUR ACCESS TOKEN HERE')

devices = pywink.get_smoke_and_co_detectors()
for sensor in devices:
    sys.stdout.write("Name: " + str(sensor.name()) + "\n")
    sys.stdout.write("ID: " + str(sensor.device_id()) + "\n")
    sys.stdout.write("Available: " + str(sensor.available) + "\n")
    sys.stdout.write("Battery: " + str(sensor.battery_level) + "\n")
    try:
        sys.stdout.write("Smoke: " + str(sensor.smoke_detected_boolean()) + "\n")
    except:
        pass
    try:
        sys.stdout.write("CO: " + str(sensor.co_detected_boolean()) + "\n")
    except:
        pass
sys.stdout.flush()
```
