### PR TITLE
Set objectprefix for smoke/co and piggy banks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Change Log
+## 0.10.1
+- Set the correct objectprefix for Wink Smoke/CO detectors and Piggy banks
+
 ## 0.10.0
 - Support for Thermostats
 

--- a/src/pywink/devices/sensors.py
+++ b/src/pywink/devices/sensors.py
@@ -4,9 +4,9 @@ from pywink.devices.base import WinkDevice
 
 class _WinkCapabilitySensor(WinkDevice):
 
-    def __init__(self, device_state_as_json, api_interface, capability, unit):
+    def __init__(self, device_state_as_json, api_interface, capability, unit, objectprefix="sensor_pods"):
         super(_WinkCapabilitySensor, self).__init__(device_state_as_json, api_interface,
-                                                    objectprefix="sensor_pods")
+                                                    objectprefix=objectprefix)
         self._capability = capability
         self.unit = unit
 
@@ -40,8 +40,6 @@ class _WinkCapabilitySensor(WinkDevice):
 
     def device_id(self):
         root_name = self.json_state.get('sensor_pod_id', None)
-        if root_name is None:
-            root_name = self.json_state.get('smoke_detector_id', self.name())
         return '{}+{}'.format(root_name, self._capability)
 
     def update_state(self, require_desired_state_fulfilled=False):
@@ -259,7 +257,7 @@ class WinkCurrencySensor(_WinkCapabilitySensor):
     def __init__(self, device_state_as_json, api_interface):
         super(WinkCurrencySensor, self).__init__(device_state_as_json, api_interface,
                                                  self.CAPABILITY,
-                                                 self.UNIT)
+                                                 self.UNIT, 'piggy_bank')
 
     @property
     def available(self):
@@ -281,6 +279,13 @@ class WinkCurrencySensor(_WinkCapabilitySensor):
         """
         return self.last_reading()
 
+    def update_state(self, require_desired_state_fulfilled=False):
+        """ Update state with latest info from Wink API. """
+        root_name = self.json_state.get('piggy_bank_id', self.name())
+        response = self.api_interface.get_device_state(self, root_name)
+        self._update_state_from_response(response,
+                                         require_desired_state_fulfilled=require_desired_state_fulfilled)
+
 
 class WinkSmokeDetector(_WinkCapabilitySensor):
 
@@ -290,7 +295,7 @@ class WinkSmokeDetector(_WinkCapabilitySensor):
     def __init__(self, device_state_as_json, api_interface):
         super(WinkSmokeDetector, self).__init__(device_state_as_json, api_interface,
                                                 self.CAPABILITY,
-                                                self.UNIT)
+                                                self.UNIT, 'smoke_detectors')
 
     def smoke_detected_boolean(self):
         """
@@ -298,6 +303,17 @@ class WinkSmokeDetector(_WinkCapabilitySensor):
         :rtype: bool
         """
         return self.last_reading()
+
+    def device_id(self):
+        root_name = self.json_state.get('smoke_detector_id', None)
+        return '{}+{}'.format(root_name, self._capability)
+
+    def update_state(self, require_desired_state_fulfilled=False):
+        """ Update state with latest info from Wink API. """
+        root_name = self.json_state.get('smoke_detector_id', self.name())
+        response = self.api_interface.get_device_state(self, root_name)
+        self._update_state_from_response(response,
+                                         require_desired_state_fulfilled=require_desired_state_fulfilled)
 
 
 class WinkCoDetector(_WinkCapabilitySensor):
@@ -308,7 +324,7 @@ class WinkCoDetector(_WinkCapabilitySensor):
     def __init__(self, device_state_as_json, api_interface):
         super(WinkCoDetector, self).__init__(device_state_as_json, api_interface,
                                              self.CAPABILITY,
-                                             self.UNIT)
+                                             self.UNIT, 'smoke_detectors')
 
     def co_detected_boolean(self):
         """
@@ -316,3 +332,14 @@ class WinkCoDetector(_WinkCapabilitySensor):
         :rtype: bool
         """
         return self.last_reading()
+
+    def device_id(self):
+        root_name = self.json_state.get('smoke_detector_id', None)
+        return '{}+{}'.format(root_name, self._capability)
+
+    def update_state(self, require_desired_state_fulfilled=False):
+        """ Update state with latest info from Wink API. """
+        root_name = self.json_state.get('smoke_detector_id', self.name())
+        response = self.api_interface.get_device_state(self, root_name)
+        self._update_state_from_response(response,
+                                         require_desired_state_fulfilled=require_desired_state_fulfilled)

--- a/src/pywink/test/devices/standard/init_test.py
+++ b/src/pywink/test/devices/standard/init_test.py
@@ -443,6 +443,15 @@ class PorkfolioTests(unittest.TestCase):
         device_id = devices[1].device_id()
         self.assertRegex(device_id, "^[0-9]{4,6}")
 
+    def test_objectprefix_should_be_correct(self):
+        with open('{}/api_responses/porkfolio.json'.format(os.path.dirname(__file__))) as porkfolio_file:
+            response_dict = json.load(porkfolio_file)
+        devices = get_devices_from_response_dict(response_dict, DEVICE_ID_KEYS[device_types.PIGGY_BANK])
+        objectprefix = devices[0].objectprefix
+        self.assertRegex(objectprefix, "piggy_bank")
+        objectprefix = devices[1].objectprefix
+        self.assertRegex(objectprefix, "piggy_bank")
+
 class RelaySensorTests(unittest.TestCase):
 
     def setUp(self):
@@ -490,4 +499,13 @@ class SmokeDetectorTests(unittest.TestCase):
         devices = get_devices_from_response_dict(response_dict, DEVICE_ID_KEYS[device_types.SMOKE_DETECTOR])
         device_id = devices[0].device_id()
         self.assertRegex(device_id, "^[0-9]{4,6}")
+
+    def test_objectprefix_should_be_correct(self):
+        with open('{}/api_responses/smoke_detector.json'.format(os.path.dirname(__file__))) as smoke_detector_file:
+            response_dict = json.load(smoke_detector_file)
+        devices = get_devices_from_response_dict(response_dict, DEVICE_ID_KEYS[device_types.SMOKE_DETECTOR])
+        objectprefix = devices[0].objectprefix
+        self.assertRegex(objectprefix, "smoke_detectors")
+        objectprefix = devices[1].objectprefix
+        self.assertRegex(objectprefix, "smoke_detectors")
 

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='python-wink',
-      version='0.10.0',
+      version='0.10.1',
       description='Access Wink devices via the Wink API',
       url='http://github.com/bradsk88/python-wink',
       author='Brad Johnson',


### PR DESCRIPTION
Found a minor bug with the last binary sensors that were added. The currency sensor, co sensor, and smoke sensor didn't have the correct object prefix set. This would make calls to the update_state function fail. This currently isn't causing issues because that method isn't called when updates are pushed with pubnub. 
