### PR TITLE
Add support for missing features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ## 0.12.1
-- Added support for additional lock, siren, and sensor attributes/features
+- Added support for additional lock, garage door, siren, and sensor attributes/features
 
 ## 0.12.0
 - Wink fan support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Change Log
 
+## 0.12.1
+- Added support for additional lock, siren, and sensor attributes/features
+
 ## 0.12.0
 - Wink fan support
-
 
 ## 0.11.0
 - Support for Wink hubs as sensors

--- a/src/pywink/devices/factory.py
+++ b/src/pywink/devices/factory.py
@@ -1,5 +1,5 @@
 from pywink.devices.base import WinkDevice
-from pywink.devices.sensors import WinkSensorPod, WinkHub
+from pywink.devices.sensors import WinkSensorPod
 from pywink.devices.standard import WinkBulb, WinkBinarySwitch, WinkPowerStripOutlet, WinkLock, \
     WinkEggTray, WinkGarageDoor, WinkShade, WinkSiren, WinkKey, WinkThermostat, \
     WinkFan
@@ -36,9 +36,5 @@ def build_device(device_state_as_json, api_interface):
         new_object = WinkThermostat(device_state_as_json, api_interface)
     elif "fan_id" in device_state_as_json:
         new_object = WinkFan(device_state_as_json, api_interface)
-    # This must be at the bottom most devices have a hub_id listed
-    # as their associated hub.
-    elif "hub_id" in device_state_as_json:
-        new_object = WinkHub(device_state_as_json, api_interface)
 
     return new_object or WinkDevice(device_state_as_json, api_interface)

--- a/src/pywink/devices/sensors.py
+++ b/src/pywink/devices/sensors.py
@@ -37,7 +37,6 @@ class _WinkCapabilitySensor(WinkDevice):
         if tamper is None:
             tamper = False
         return tamper
-        
 
     @property
     def battery_level(self):

--- a/src/pywink/devices/sensors.py
+++ b/src/pywink/devices/sensors.py
@@ -32,6 +32,14 @@ class _WinkCapabilitySensor(WinkDevice):
         return name
 
     @property
+    def tamper_detected(self):
+        tamper = self._last_reading.get('tamper_detected', False)
+        if tamper is None:
+            tamper = False
+        return tamper
+        
+
+    @property
     def battery_level(self):
         if not self._last_reading.get('external_power', None):
             return self._last_reading.get('battery', None)

--- a/src/pywink/devices/standard/__init__.py
+++ b/src/pywink/devices/standard/__init__.py
@@ -66,15 +66,15 @@ class WinkLock(WinkDevice):
         return self._last_reading.get('alarm_mode', None)
 
     @property
-    def vacation_mode(self):
+    def vacation_mode_enabled(self):
         return self._last_reading.get('vacation_mode_enabled', False)
 
     @property
-    def beeper(self):
+    def beeper_enabled(self):
         return self._last_reading.get('beeper_enabled', False)
 
     @property
-    def auto_lock(self):
+    def auto_lock_enabled(self):
         return self._last_reading.get('auto_lock_enabled', False)
 
     @property
@@ -308,10 +308,12 @@ class WinkSiren(WinkBinarySwitch):
     def device_id(self):
         return self.json_state.get('siren_id', self.name())
 
-    def current_mode(self):
+    @property
+    def mode(self):
         return self._last_reading.get('mode', None)
 
-    def current_auto_shutoff(self):
+    @property
+    def auto_shutoff(self):
         return self._last_reading.get('auto_shutoff', None)
 
     def set_mode(self, mode):
@@ -327,14 +329,14 @@ class WinkSiren(WinkBinarySwitch):
         response = self.api_interface.set_device_state(self, values)
         self._update_state_from_response(response)
 
-    def set_auto_shutoff(self, time):
+    def set_auto_shutoff(self, timer):
         """
         :param time: an int, one of [None (never), 30, 60, 120]
         :return: nothing
         """
         values = {
             "desired_state": {
-                "auto_shutoff": time
+                "auto_shutoff": timer
             }
         }
         response = self.api_interface.set_device_state(self, values)

--- a/src/pywink/devices/standard/__init__.py
+++ b/src/pywink/devices/standard/__init__.py
@@ -57,6 +57,45 @@ class WinkLock(WinkDevice):
     def device_id(self):
         return self.json_state.get('lock_id', self.name())
 
+    def alarm_status(self):
+        return self.json_state.get('alarm_enabled', False)
+
+    def vacation_mode_status(self):
+        return self.json_state.get('vacation_mode_enabled', False)
+
+    def beeper_status(self):
+        return self.json_state.get('beeper_enabled', False)
+
+    def auto_lock_status(self):
+        return self.json_state.get('auto_lock_enabled', False)
+
+    def set_alarm_state(self):
+        """
+        :param state: a boolean of ture (on) or false ('off')
+        :return: nothing
+        """
+        values = {"desired_state": {"alarm_enabled": state}}
+        response = self.api_interface.set_device_state(self, values)
+        self._update_state_from_response(response)
+
+    def set_vacation_mode(self):
+        """
+        :param state: a boolean of ture (on) or false ('off')
+        :return: nothing
+        """
+        values = {"desired_state": {"vacation_mode_enabled": state}}
+        response = self.api_interface.set_device_state(self, values)
+        self._update_state_from_response(response)
+
+    def set_beeper_mode(self):
+        """
+        :param state: a boolean of ture (on) or false ('off')
+        :return: nothing
+        """
+        values = {"desired_state": {"beeper_enabled": state}}
+        response = self.api_interface.set_device_state(self, values)
+        self._update_state_from_response(response)
+
     def set_state(self, state):
         """
         :param state:   a boolean of true (on) or false ('off')
@@ -171,6 +210,13 @@ class WinkGarageDoor(WinkDevice):
     def device_id(self):
         return self.json_state.get('garage_door_id', self.name())
 
+    @property
+    def tamper_detected(self):
+        tamper = self._last_reading.get('tamper_detected_true', False)
+        if tamper is None:
+            tamper = False
+        return tamper
+
     def set_state(self, state):
         """
         :param state:   a number of 1 ('open') or 0 ('close')
@@ -230,6 +276,42 @@ class WinkSiren(WinkBinarySwitch):
 
     def device_id(self):
         return self.json_state.get('siren_id', self.name())
+
+    def current_mode(self):
+        return self._last_reading.get('mode', None)
+
+    def current_auto_shutoff(self):
+        return self._last_reading('auto_shutoff', None)
+
+    def set_mode(self, mode):
+        """
+        :param mode:  a str, one of [siren_only, strobe_only, siren_and_strobe]
+        :return: nothing
+        """
+        values = {
+            "desired_state": {
+                "mode": mode
+            }
+        }
+        response = self.api_interface.set_device_state(self, values)
+        self._update_state_from_response(response)
+
+        self._last_call = (time.time(), state)
+
+    def set_auto_shutoff(self, time):
+        """
+        :param time: an int, one of [None (never), 30, 60, 120]
+        :return: nothing
+        """
+        values = {
+            "desired_state": {
+                "auto_shutoff": time
+            }
+        }
+        response = self.api_interface.set_device_state(self, values)
+        self._update_state_from_response(response)
+
+        self._last_call = (time.time(), state)
 
 
 class WinkKey(WinkDevice):

--- a/src/pywink/devices/types.py
+++ b/src/pywink/devices/types.py
@@ -13,6 +13,8 @@ SMOKE_DETECTOR = 'smoke_detector'
 THERMOSTAT = 'thermostat'
 HUB = 'hub'
 FAN = 'fan'
+BUTTON = 'button'
+REMOTE = 'remote'
 
 DEVICE_ID_KEYS = {
     BINARY_SWITCH: 'binary_switch_id',
@@ -29,5 +31,7 @@ DEVICE_ID_KEYS = {
     SMOKE_DETECTOR: 'smoke_detector_id',
     THERMOSTAT: 'thermostat_id',
     HUB: 'hub_id',
-    FAN: 'fan_id'
+    FAN: 'fan_id',
+    BUTTON: 'button_id',
+    REMOTE: 'remote_id'
 }

--- a/src/pywink/test/devices/standard/init_test.py
+++ b/src/pywink/test/devices/standard/init_test.py
@@ -69,6 +69,14 @@ class GarageDoorTests(unittest.TestCase):
         device_id = wink_garage_door.device_id()
         self.assertRegex(device_id, "^[0-9]{4,6}$")
 
+    def test_tamper_detected_should_be_false(self):
+        with open('{}/api_responses/garage_door.json'.format(os.path.dirname(__file__))) as garage_door_file:
+            response_dict = json.load(garage_door_file)
+        garage_door = response_dict.get('data')[0]
+        wink_garage_door = WinkGarageDoor(garage_door, self.api_interface)
+        tamper = wink_garage_door.tamper_detected
+        self.assertFalse(tamper)
+
 
 class ShadeTests(unittest.TestCase):
     def setUp(self):
@@ -113,6 +121,22 @@ class SirenTests(unittest.TestCase):
         device_id = wink_siren.device_id()
         self.assertRegex(device_id, "^[0-9]{4,6}$")
 
+    def test_auto_shutoff_should_be_30(self):
+        with open('{}/api_responses/siren.json'.format(os.path.dirname(__file__))) as siren_file:
+            response_dict = json.load(siren_file)
+        siren = response_dict.get('data')[0]
+        wink_siren = WinkSiren(siren, self.api_interface)
+        auto_shutoff = wink_siren.auto_shutoff
+        self.assertEqual(auto_shutoff, 30)
+
+    def test_mode_should_be_siren_and_strobe(self):
+        with open('{}/api_responses/siren.json'.format(os.path.dirname(__file__))) as siren_file:
+            response_dict = json.load(siren_file)
+        siren = response_dict.get('data')[0]
+        wink_siren = WinkSiren(siren, self.api_interface)
+        mode = wink_siren.mode
+        self.assertEqual(mode, "siren_and_strobe")
+
 
 class LockTests(unittest.TestCase):
 
@@ -134,6 +158,46 @@ class LockTests(unittest.TestCase):
         wink_lock = WinkLock(lock, self.api_interface)
         device_id = wink_lock.device_id()
         self.assertRegex(device_id, "^[0-9]{4,6}$")
+
+    def test_alarm_mode_should_be_null(self):
+        with open('{}/api_responses/lock.json'.format(os.path.dirname(__file__))) as lock_file:
+            response_dict = json.load(lock_file)
+        lock = response_dict.get('data')[0]
+        wink_lock = WinkLock(lock, self.api_interface)
+        alarm_mode = wink_lock.alarm_mode
+        self.assertEqual(alarm_mode, None)
+
+    def test_alarm_sensitivity_should_be_6(self):
+        with open('{}/api_responses/lock.json'.format(os.path.dirname(__file__))) as lock_file:
+            response_dict = json.load(lock_file)
+        lock = response_dict.get('data')[0]
+        wink_lock = WinkLock(lock, self.api_interface)
+        alarm_sensitivity = wink_lock.alarm_sensitivity
+        self.assertEqual(alarm_sensitivity, 0.6)
+
+    def test_alarm_enabled_should_be_true(self):
+        with open('{}/api_responses/lock.json'.format(os.path.dirname(__file__))) as lock_file:
+            response_dict = json.load(lock_file)
+        lock = response_dict.get('data')[0]
+        wink_lock = WinkLock(lock, self.api_interface)
+        alarm_enabled = wink_lock.alarm_enabled
+        self.assertTrue(alarm_enabled)
+
+    def test_beeper_enabled_should_be_true(self):
+        with open('{}/api_responses/lock.json'.format(os.path.dirname(__file__))) as lock_file:
+            response_dict = json.load(lock_file)
+        lock = response_dict.get('data')[0]
+        wink_lock = WinkLock(lock, self.api_interface)
+        beeper_enabled = wink_lock.beeper_enabled
+        self.assertTrue(beeper_enabled)
+
+    def test_vacation_mode_enabled_should_be_false(self):
+        with open('{}/api_responses/lock.json'.format(os.path.dirname(__file__))) as lock_file:
+            response_dict = json.load(lock_file)
+        lock = response_dict.get('data')[0]
+        wink_lock = WinkLock(lock, self.api_interface)
+        vacation_mode_enabled = wink_lock.vacation_mode_enabled
+        self.assertFalse(vacation_mode_enabled)
 
 
 class BinarySwitchTests(unittest.TestCase):
@@ -305,6 +369,14 @@ class SensorTests(unittest.TestCase):
 
         for sensor in sensors:
             self.assertEqual(sensor.battery_level, 0.86)
+
+    def test_sensor_tamper_detected_should_be_false(self):
+        response = ApiResponseJSONLoader('door_sensor_gocontrol.json').load()
+        devices = get_devices_from_response_dict(response,
+                                                 DEVICE_ID_KEYS[
+                                                     device_types.SENSOR_POD])
+        tamper = devices[0].tamper_detected
+        self.assertFalse(tamper)
 
     def test_gocontrol_door_sensor_should_be_identified(self):
         response = ApiResponseJSONLoader('door_sensor_gocontrol.json').load()

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='python-wink',
-      version='0.12.0',
+      version='0.12.1',
       description='Access Wink devices via the Wink API',
       url='http://github.com/bradsk88/python-wink',
       author='Brad Johnson',


### PR DESCRIPTION
Locks, garage doors, sirens, and sensors all had additional features that can be monitored and controlled. This adds support for this missing features.

Locks
- alarm_mode "activity", "tamper", "forced_entry" (set and monitor)
- alarm_sensitivity 1.0 for Very sensitive, 0.2 for not sensitive, steps in values of 0.2 (set and monitor)
- auto_lock_enabled (set and monitor)
- beeper_enabled (set and monitor)
- vacation_mode (set and monitor)

Garage doors and sensors
- tamper detected (monitor)

Sirens
- mode [siren_only, strobe_only, siren_and_strobe] (set and monitor)
- auto_shutoff one of [null (never), 30, 60, 120]. Values are in seconds. (set and monitor)

