### PR TITLE
Set object_id and object_type when creating device.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 1.1.1
+- Bugfix for lutron lights missing object_id and object_type
+
 ## 1.1.0
 - Support for Quirky Aros AC units
 - Support for Quirky Refuel

--- a/src/pywink/devices/base.py
+++ b/src/pywink/devices/base.py
@@ -12,6 +12,8 @@ class WinkDevice(object):
         self.json_state = device_state_as_json
         self.pubnub_key = None
         self.pubnub_channel = None
+        self.obj_id = self.json_state.get('object_id')
+        self.obj_type = self.json_state.get('object_type')
         subscription = self.json_state.get('subscription')
         if subscription != {} and subscription is not None:
             pubnub = subscription.get('pubnub')
@@ -25,10 +27,10 @@ class WinkDevice(object):
         raise NotImplementedError("Must implement state")
 
     def object_id(self):
-        return self.json_state.get('object_id')
+        return self.obj_id
 
     def object_type(self):
-        return self.json_state.get("object_type")
+        return self.obj_type
 
     @property
     def _last_reading(self):
@@ -61,8 +63,11 @@ class WinkDevice(object):
         :return:
         """
         _response_json = response_json.get('data')
-        self.json_state = _response_json
-        return True
+        if _response_json is not None:
+            self.json_state = _response_json
+            return True
+        else:
+            return False
 
     def update_state(self):
         """ Update state with latest info from Wink API. """
@@ -70,4 +75,7 @@ class WinkDevice(object):
         return self._update_state_from_response(response)
 
     def pubnub_update(self, json_response):
-        self.json_state = json_response
+        if json_response is not None:
+            self.json_state = json_response
+        else:
+            self.update_state()

--- a/src/pywink/devices/light_bulb.py
+++ b/src/pywink/devices/light_bulb.py
@@ -71,13 +71,11 @@ class WinkLightBulb(WinkDevice):
         desired_state = {"powered": state}
 
         color_state = self._format_color_data(color_hue_saturation, color_kelvin, color_xy)
-        desired_state.update(color_state)
+        if color_state is not None:
+            desired_state.update(color_state)
 
-        brightness = brightness if brightness is not None \
-            else self.json_state.get('last_reading', {}).get('desired_brightness', 1)
-        desired_state.update({
-            'brightness': brightness
-        })
+        if brightness is not None:
+            desired_state.update({'brightness': brightness})
 
         response = self.api_interface.set_device_state(self, {
             "desired_state": desired_state
@@ -86,7 +84,7 @@ class WinkLightBulb(WinkDevice):
 
     def _format_color_data(self, color_hue_saturation, color_kelvin, color_xy):
         if color_hue_saturation is None and color_kelvin is None and color_xy is None:
-            return {}
+            return None
 
         if self.supports_rgb():
             rgb = _get_color_as_rgb(color_hue_saturation, color_kelvin, color_xy)

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='python-wink',
-      version='1.1.0',
+      version='1.1.1',
       description='Access Wink devices via the Wink API',
       url='http://github.com/python-wink/python-wink',
       author='Brad Johnson',


### PR DESCRIPTION
@cbulock found an issue resulting in lights not working after a state change. After tons of debugging and testing it turns out that that some devices, in this case Caseta Wireless Dimmers, don't return their object_id and object_type when receiving a state update from pubnub. This is clearing an issue with Wink. However, since the object_id and object_type are present when pulling the device's info from Wink's API this PR just sets those in variables and never queries the json_state for them again. 

There are also a few changes in the light_bulb.py code that were added as a result of testing that I think make sense so I left them in. Same with the validation of the JSON in the update methods. 