### PR TITLE
Support for robots and scenes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 1.2.0
+- Robot and Scene support
+
 ## 1.1.1
 - Bugfix for lutron lights missing object_id and object_type
 

--- a/src/pywink/__init__.py
+++ b/src/pywink/__init__.py
@@ -10,7 +10,7 @@ from pywink.api import set_bearer_token, refresh_access_token, \
 from pywink.api import get_light_bulbs, get_garage_doors, get_locks, \
     get_powerstrips, get_shades, get_sirens, \
     get_switches, get_thermostats, get_fans, get_air_conditioners, \
-    get_propane_tanks
+    get_propane_tanks, get_robots, get_scenes
 
 from pywink.api import get_all_devices, get_eggtrays, get_sensors, \
     get_keys, get_piggy_banks, get_smoke_and_co_detectors, \

--- a/src/pywink/devices/eggtray.py
+++ b/src/pywink/devices/eggtray.py
@@ -8,12 +8,12 @@ class WinkEggtray(WinkDevice):
 
     def __init__(self, device_state_as_json, api_interface):
         super(WinkEggtray, self).__init__(device_state_as_json, api_interface)
-        self._cap = None
+        self._capability = None
         self._unit = "eggs"
 
     def capability(self):
         # Eggtray has no capability.
-        return self._cap
+        return self._capability
 
     def unit(self):
         return self._unit

--- a/src/pywink/devices/factory.py
+++ b/src/pywink/devices/factory.py
@@ -25,6 +25,8 @@ from pywink.devices.smoke_detector import WinkSmokeDetector, WinkSmokeSeverity, 
 from pywink.devices.camera import WinkCanaryCamera
 from pywink.devices.air_conditioner import WinkAirConditioner
 from pywink.devices.propane_tank import WinkPropaneTank
+from pywink.devices.robot import WinkRobot
+from pywink.devices.scene import WinkScene
 
 
 # pylint: disable=redefined-variable-type,too-many-branches, too-many-statements
@@ -97,6 +99,10 @@ def build_device(device_state_as_json, api_interface):
         new_object = WinkAirConditioner(device_state_as_json, api_interface)
     elif object_type == device_types.PROPANE_TANK:
         new_object = WinkPropaneTank(device_state_as_json, api_interface)
+    elif object_type == device_types.ROBOT:
+        new_object = WinkRobot(device_state_as_json, api_interface)
+    elif object_type == device_types.SCENE:
+        new_object = WinkScene(device_state_as_json, api_interface)
 
     if new_object is not None:
         return [new_object]

--- a/src/pywink/devices/light_bulb.py
+++ b/src/pywink/devices/light_bulb.py
@@ -18,6 +18,9 @@ class WinkLightBulb(WinkDevice):
     def brightness(self):
         return self._last_reading.get('brightness')
 
+    def color_model(self):
+        return self._last_reading.get('color_model')
+
     def color_xy(self):
         """
         XY colour value: [float, float] or None

--- a/src/pywink/devices/propane_tank.py
+++ b/src/pywink/devices/propane_tank.py
@@ -8,12 +8,12 @@ class WinkPropaneTank(WinkDevice):
 
     def __init__(self, device_state_as_json, api_interface):
         super(WinkPropaneTank, self).__init__(device_state_as_json, api_interface)
-        self._cap = None
+        self._capability = None
         self._unit = None
 
     def capability(self):
         # Propane tanks have no capability.
-        return self._cap
+        return self._capability
 
     def unit(self):
         return self._unit

--- a/src/pywink/devices/robot.py
+++ b/src/pywink/devices/robot.py
@@ -1,31 +1,29 @@
 from pywink.devices.base import WinkDevice
 
 
-class WinkKey(WinkDevice):
+class WinkRobot(WinkDevice):
     """
-    Represents a Wink key.
+    Represents a Wink robot.
     """
 
     def __init__(self, device_state_as_json, api_interface):
-        super(WinkKey, self).__init__(device_state_as_json, api_interface)
+        super(WinkRobot, self).__init__(device_state_as_json, api_interface)
         self._available = True
+        self._capability = "fired"
         self._unit = None
-        self._capability = "activity_detected"
 
     def state(self):
         return self._last_reading.get(self.capability(), False)
 
-    def parent_id(self):
-        return self.json_state.get('parent_object_id')
-
     def available(self):
-        """Keys are virtual therefore they don't have a connection status
-        always return True
+        """
+        Robots are virtual therefore they don't have a connection status
+        always return True.
         """
         return self._available
 
     def unit(self):
-        # Keys are a boolean sensor, they have no unit.
+        # Robots are a boolean sensor, they have no unit.
         return self._unit
 
     def capability(self):

--- a/src/pywink/devices/scene.py
+++ b/src/pywink/devices/scene.py
@@ -1,0 +1,37 @@
+from pywink.devices.base import WinkDevice
+
+
+class WinkScene(WinkDevice):
+    """
+    Represents a Wink scene.
+    """
+
+    def __init__(self, device_state_as_json, api_interface):
+        super(WinkScene, self).__init__(device_state_as_json, api_interface)
+
+    def state(self):
+        """
+        Scenes don't have a state, they can only be triggered.
+        Always return a state of False.
+        """
+        return False
+
+    def available(self):
+        """
+        Scenes are virtual therefore they don't have a connection status
+        always return True.
+        """
+        return True
+
+    def activate(self):
+        """
+        Activate the scene.
+        """
+        response = self.api_interface.set_device_state(self, None)
+        self._update_state_from_response(response)
+
+    def update_state(self):
+        """
+        Nothing changes in the JSON state of this device.
+        """
+        return True

--- a/src/pywink/devices/smoke_detector.py
+++ b/src/pywink/devices/smoke_detector.py
@@ -8,7 +8,7 @@ class WinkBaseSmokeDetector(WinkDevice):
         super(WinkBaseSmokeDetector, self).__init__(device_state_as_json, api_interface)
         self._unit = None
         self._unit_type = unit_type
-        self._cap = capability
+        self._capability = capability
 
     def unit(self):
         return self._unit
@@ -17,7 +17,7 @@ class WinkBaseSmokeDetector(WinkDevice):
         return self._unit_type
 
     def capability(self):
-        return self._cap
+        return self._capability
 
     def name(self):
         return self.json_state.get("name") + " " + self.capability()

--- a/src/pywink/devices/types.py
+++ b/src/pywink/devices/types.py
@@ -25,9 +25,11 @@ GANG = 'gang'
 CAMERA = 'camera'
 AIR_CONDITIONER = 'air_conditioner'
 PROPANE_TANK = 'propane_tank'
+ROBOT = 'robot'
+SCENE = 'scene'
 
 ALL_SUPPORTED_DEVICES = [LIGHT_BULB, BINARY_SWITCH, SENSOR_POD, LOCK, EGGTRAY,
                          GARAGE_DOOR, POWERSTRIP, SHADE, SIREN, KEY, PIGGY_BANK,
                          SMOKE_DETECTOR, THERMOSTAT, HUB, FAN, DOOR_BELL, REMOTE,
                          SPRINKLER, BUTTON, GANG, CAMERA, AIR_CONDITIONER,
-                         PROPANE_TANK]
+                         PROPANE_TANK, ROBOT, SCENE]

--- a/src/pywink/test/api_test.py
+++ b/src/pywink/test/api_test.py
@@ -36,6 +36,8 @@ from pywink.devices.sprinkler import WinkSprinkler
 from pywink.devices.camera import WinkCanaryCamera
 from pywink.devices.air_conditioner import WinkAirConditioner
 from pywink.devices.propane_tank import WinkPropaneTank
+from pywink.devices.scene import WinkScene
+from pywink.devices.robot import WinkRobot
 
 USERS_ME_WINK_DEVICES = {}
 
@@ -83,7 +85,7 @@ class ApiTests(unittest.TestCase):
     def test_get_all_devices_from_api(self):
         WinkApiInterface.BASE_URL = "http://localhost:" + str(self.port)
         devices = get_all_devices()
-        self.assertEqual(len(devices), 61)
+        self.assertEqual(len(devices), 63)
         lights = get_light_bulbs()
         for light in lights:
             self.assertTrue(isinstance(light, WinkLightBulb))
@@ -150,8 +152,9 @@ class ApiTests(unittest.TestCase):
         WinkApiInterface.BASE_URL = "http://localhost:" + str(self.port)
         sensor_types = [WinkSensor, WinkHub, WinkPorkfolioBalanceSensor, WinkKey, WinkRemote,
                         WinkGang, WinkSmokeDetector, WinkSmokeSeverity,
-                        WinkCoDetector, WinkCoSeverity, WinkButton]
-        skip_types = [WinkPowerStripOutlet, WinkCanaryCamera]
+                        WinkCoDetector, WinkCoSeverity, WinkButton, WinkRobot]
+        # No way to validate scene is activated, so skipping.
+        skip_types = [WinkPowerStripOutlet, WinkCanaryCamera, WinkScene]
         devices = get_all_devices()
         old_states = {}
         for device in devices:

--- a/src/pywink/test/devices/api_responses/robot.json
+++ b/src/pywink/test/devices/api_responses/robot.json
@@ -1,0 +1,79 @@
+{
+  "robot_id": "4830303",
+  "name": "Test robot",
+  "enabled": true,
+  "creating_actor_type": "user",
+  "creating_actor_id": "377857",
+  "automation_mode": null,
+  "fired_limit": 0,
+  "last_fired": null,
+  "object_type": "robot",
+  "object_id": "4830303",
+  "uuid": "ca476195-6780-46ddXXXXXXXXXXXXXXXXXx",
+  "icon_id": "191",
+  "icon_code": "robot-robot",
+  "desired_state": {
+    "enabled": true,
+    "fired_limit": 0
+  },
+  "last_reading": {
+    "fired_true": "N/A",
+    "fired_true_updated_at": null,
+    "enabled": true,
+    "enabled_updated_at": 1487361095.4796422,
+    "fired_limit": 0,
+    "fired_limit_updated_at": null,
+    "fired_count": 0,
+    "fired_count_updated_at": null,
+    "fired": false,
+    "fired_updated_at": null,
+    "failure_email_sent": null,
+    "failure_email_sent_updated_at": null,
+    "desired_enabled_updated_at": 1487361228.0143569,
+    "desired_fired_limit_updated_at": 1487361228.0143569,
+    "desired_enabled_changed_at": 1487361095.483048,
+    "desired_fired_limit_changed_at": 1487361228.0143569
+  },
+  "subscription": {
+    "pubnub": {
+      "subscribe_key": "sub-c-XXXXXXXXXXx-XXXXXXXXXXXXXXXx",
+      "channel": "1340f4f4ec705946fXXXXXXXXXXXXx"
+    }
+  },
+  "effects": [
+    {
+      "effect_id": "8966813",
+      "robot_id": "4830303",
+      "notification_type": "push",
+      "recipient_actor_type": "user",
+      "recipient_actor_id": "377857",
+      "scene": null,
+      "note": null,
+      "reference_object_type": null,
+      "reference_object_id": null,
+      "object_type": "effect",
+      "object_id": "8966813"
+    }
+  ],
+  "causes": [
+    {
+      "next_at": null,
+      "recurrence": null,
+      "object_type": "condition",
+      "object_id": "7534749",
+      "condition_id": "7534749",
+      "robot_id": "4830303",
+      "observed_object_id": "4438018",
+      "observed_object_type": "group",
+      "observed_field": "liquid_detected.or",
+      "operator": "==",
+      "value": "true",
+      "delay": null,
+      "restricted_object_id": null,
+      "restricted_object_type": null,
+      "restriction_join": null,
+      "restrictions": []
+    }
+  ],
+  "restrictions": []
+}

--- a/src/pywink/test/devices/api_responses/scene.json
+++ b/src/pywink/test/devices/api_responses/scene.json
@@ -1,0 +1,27 @@
+{
+  "scene_id": "5156247",
+  "name": "New Shortcut",
+  "order": 0,
+  "members": [
+    {
+      "object_type": "binary_switch",
+      "object_id": "292860",
+      "desired_state": {
+        "powered": true
+      },
+      "local_scene_id": null
+    }
+  ],
+  "icon_id": "224",
+  "automation_mode": null,
+  "object_type": "scene",
+  "object_id": "5156247",
+  "uuid": "b0e859ba-a270-4139-8XXXXXXXXXX",
+  "icon_code": "scene-shortcut",
+  "subscription": {
+    "pubnub": {
+      "subscribe_key": "sub-c-XXXXXXXXXXXXXXXXXXXXXX",
+      "channel": "2c78283d58f4559a2"
+    }
+  }
+}

--- a/src/pywink/test/devices/base_test.py
+++ b/src/pywink/test/devices/base_test.py
@@ -24,6 +24,8 @@ from pywink.devices.gang import WinkGang
 from pywink.devices.camera import WinkCanaryCamera
 from pywink.devices.air_conditioner import WinkAirConditioner
 from pywink.devices.propane_tank import WinkPropaneTank
+from pywink.devices.scene import WinkScene
+from pywink.devices.robot import WinkRobot
 
 
 class BaseTests(unittest.TestCase):
@@ -81,7 +83,7 @@ class BaseTests(unittest.TestCase):
         skip_types = [WinkFan, WinkPorkfolioBalanceSensor, WinkPorkfolioNose, WinkBinarySwitch, WinkHub,
                       WinkLightBulb, WinkThermostat, WinkKey, WinkPowerStrip, WinkPowerStripOutlet,
                       WinkRemote, WinkShade, WinkSprinkler, WinkButton, WinkGang, WinkCanaryCamera,
-                      WinkAirConditioner]
+                      WinkAirConditioner, WinkScene, WinkRobot]
         for device in devices:
             if device.manufacturer_device_model() == "leaksmart_valve":
                 self.assertIsNotNone(device.battery_level())
@@ -100,10 +102,11 @@ class BaseTests(unittest.TestCase):
         devices = get_devices_from_response_dict(self.response_dict, device_types.ALL_SUPPORTED_DEVICES)
         skip_types = [WinkKey, WinkPorkfolioBalanceSensor, WinkPorkfolioNose, WinkPowerStripOutlet,
                       WinkSiren, WinkEggtray, WinkRemote, WinkPowerStrip, WinkAirConditioner, WinkPropaneTank]
+        devices_with_no_device_model = ["GoControl Thermostat", "New Shortcut", "Test robot"]
         for device in devices:
             if type(device) in skip_types:
                 self.assertIsNone(device.manufacturer_device_model())
-            elif device.name() == "GoControl Thermostat":
+            elif device.name() in devices_with_no_device_model:
                 self.assertIsNone(device.manufacturer_device_model())
             else:
                 self.assertIsNotNone(device.manufacturer_device_model())
@@ -116,7 +119,7 @@ class BaseTests(unittest.TestCase):
                                           "ge_bulb", "quirky_ge_spotter", "schlage_zwave_lock", "home_decorators_home_decorators_fan",
                                           "sylvania_sylvania_rgbw", "somfy_bali", "wink_relay_sensor", "wink_project_one", "kidde_smoke_alarm",
                                           "wink_relay_switch", "leaksmart_valve"]
-        skip_names = ["GoControl Thermostat", "GE Zwave Switch"]
+        skip_names = ["GoControl Thermostat", "GE Zwave Switch", "New Shortcut", "Test robot"]
         for device in devices:
             if device.name() in skip_names:
                 self.assertIsNone(device.manufacturer_device_id())
@@ -129,10 +132,11 @@ class BaseTests(unittest.TestCase):
 
     def test_all_devices_device_manufacturer_is_valid(self):
         devices = get_devices_from_response_dict(self.response_dict, device_types.ALL_SUPPORTED_DEVICES)
+        device_with_no_manufacturer = ["GoControl Thermostat", "New Shortcut", "Test robot"]
         for device in devices:
             if type(device) is WinkKey:
                 self.assertIsNone(device.device_manufacturer())
-            elif device.name() == "GoControl Thermostat":
+            elif device.name() in device_with_no_manufacturer:
                 self.assertIsNone(device.device_manufacturer())
             elif type(device) is WinkPowerStripOutlet:
                 self.assertIsNone(device.device_manufacturer())
@@ -141,10 +145,11 @@ class BaseTests(unittest.TestCase):
 
     def test_all_devices_model_name_is_valid(self):
         devices = get_devices_from_response_dict(self.response_dict, device_types.ALL_SUPPORTED_DEVICES)
+        devices_with_no_model_name = ["GoControl Thermostat", "New Shortcut", "Test robot"]
         for device in devices:
             if type(device) is WinkKey:
                 self.assertIsNone(device.model_name())
-            elif device.name() == "GoControl Thermostat":
+            elif device.name() in devices_with_no_model_name:
                 self.assertIsNone(device.model_name())
             elif type(device) is WinkPowerStripOutlet:
                 self.assertIsNone(device.model_name())

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='python-wink',
-      version='1.1.1',
+      version='1.2.0',
       description='Access Wink devices via the Wink API',
       url='http://github.com/python-wink/python-wink',
       author='Brad Johnson',


### PR DESCRIPTION
Like the title says. This adds support for scenes which because a binary_switch basically (can only be turned on) and robots which are binary_sensors. The robot functionality doesn't seem to work in Home-Assistant because the "on" state doesn't get sent back from pubnub, only the off state. This means the sensors never turn on. I think this may be a bug on Wink's side, so it is worth adding to python-wink just in case it starts working. 

Unfortunately neither of these come back with the standard devices, which means the API fetching logic needed changed a bit to grab them. 

Also added the ability to pull back the current color_model from light_bulbs. This will allow me to fix a bug in Home-Assistant where Color bulbs will display as whatever color they were last even if they are set to temperature mode.