### PR TITLE
Set api fetch default endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 1.2.1
+- Set default endpoint in wink_api_fetch
+
 ## 1.2.0
 - Robot and Scene support
 

--- a/src/pywink/api.py
+++ b/src/pywink/api.py
@@ -243,7 +243,7 @@ def get_scenes():
 
 
 def get_subscription_key():
-    response_dict = wink_api_fetch('wink_devices')
+    response_dict = wink_api_fetch()
     first_device = response_dict.get('data')[0]
     return get_subscription_key_from_response_dict(first_device)
 
@@ -255,7 +255,7 @@ def get_subscription_key_from_response_dict(device):
         return None
 
 
-def wink_api_fetch(end_point):
+def wink_api_fetch(end_point='wink_devices'):
     arequest_url = "{}/users/me/{}".format(WinkApiInterface.BASE_URL, end_point)
     response = requests.get(arequest_url, headers=API_HEADERS)
     if response.status_code == 200:

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='python-wink',
-      version='1.2.0',
+      version='1.2.1',
       description='Access Wink devices via the Wink API',
       url='http://github.com/python-wink/python-wink',
       author='Brad Johnson',


### PR DESCRIPTION
In order to keep pubnub updates flowing the Wink API needs to be polled every so often. This is done by another library which calls python-winks wink_api_fetch method. However, with the recent changes for scene and robot support an endpoint needs to be provided for that method to work. This change sets a default endpoint so it doesn't need hard coded into the pubnubsub-handler library that calls python-wink. 