### PR TITLE
[WIP] Local control (No root required)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 1.4.0
+- Local control support for lights, locks, and switches
+
 ## 1.3.1
 - Fixed fans speed selection
 
@@ -105,10 +108,10 @@
 ## 0.7.6
 - Added ability to return the battery level if a device is battery powered
 
-## 0.7.5 
+## 0.7.5
 - Fixed bug where light bulb states were not updating.
 
-## 0.7.4 
+## 0.7.4
 - Fixed bug where we shouldn't have been indexing into an object
 
 ## 0.7.3
@@ -117,12 +120,12 @@
 ## 0.7.2
 - Conserving brightness when setting color (temperature, hue sat, etc.)
 
-## 0.7.1 
+## 0.7.1
 - Exposed bulb color support methods (E.g. supports_hue_saturation())
 
 ## 0.7.0
 - Expanded color support for WinkBulbs
-- Added ability to supply client_id, client_secret, and refresh_token 
+- Added ability to supply client_id, client_secret, and refresh_token
 instead of access_token.  This should get around tokens expiring.
 
 ## 0.6.4
@@ -138,11 +141,11 @@ instead of access_token.  This should get around tokens expiring.
 ## 0.6.1
 - Return the capability of a sensor as part of the name.
 
-## 0.6.0 
+## 0.6.0
 - Major structural change.  Using modules to avoid circular dependencies.
 - Added support for devices that contain multiple onboard sensors.
 
-## 0.5.0 
+## 0.5.0
 - Major bug fix.  Methods like `get_bulbs` were always returning empty lists.
 
 ## 0.4.3
@@ -170,7 +173,7 @@ instead of access_token.  This should get around tokens expiring.
 ## 0.3.1
 - Added init method for WinkEggTray
 
-## 0.3.0 
+## 0.3.0
 - Breaking change: Renamed classes to satisfy pylint
 
 ## 0.2.1

--- a/script/lint
+++ b/script/lint
@@ -2,11 +2,13 @@
 
 cd "$(dirname "$0")/.."
 
+flake8 --version
 echo "Checking style with flake8..."
 flake8 src/pywink
 
 FLAKE8_STATUS=$?
 
+pylint --version
 echo "Checking style with pylint..."
 pylint src/pywink
 PYLINT_STATUS=$?

--- a/src/pywink/__init__.py
+++ b/src/pywink/__init__.py
@@ -3,10 +3,10 @@ Top level functions
 """
 # noqa
 from pywink.api import set_bearer_token, refresh_access_token, \
-    set_wink_credentials, set_user_agent, wink_api_fetch, \
-    get_set_access_token, is_token_set, get_devices, \
+    set_wink_credentials, set_user_agent, wink_api_fetch, get_devices, \
     get_subscription_key, get_user, get_authorization_url, \
-    request_token, legacy_set_wink_credentials
+    request_token, legacy_set_wink_credentials, get_current_oauth_credentials, \
+    disable_local_control
 
 from pywink.api import get_light_bulbs, get_garage_doors, get_locks, \
     get_powerstrips, get_shades, get_sirens, \

--- a/src/pywink/devices/base.py
+++ b/src/pywink/devices/base.py
@@ -32,6 +32,19 @@ class WinkDevice(object):
     def object_type(self):
         return self.obj_type
 
+    def hub_id(self):
+        return self.json_state.get('hub_id')
+
+    def local_id(self):
+        # Devices with a "gang" controlling them (Ceiling fans and their associated light)
+        # must be controlled by the gang's local control ID.
+        # These devices local control ID is in the following format (gang_id.their_id)
+        # Stripping the trailing ID so the first ID is always used.
+        _local_id = self.json_state.get('local_id')
+        if _local_id is not None:
+            _local_id = _local_id.split(".")[0]
+        return _local_id
+
     @property
     def _last_reading(self):
         return self.json_state.get('last_reading') or {}
@@ -41,8 +54,14 @@ class WinkDevice(object):
 
     def battery_level(self):
         if not self._last_reading.get('external_power'):
-            return self._last_reading.get('battery')
-        return None
+            try:
+                _battery = self._last_reading.get('battery')
+                _battery = float(_battery)
+                return _battery
+            except TypeError:
+                return None
+        else:
+            return None
 
     def manufacturer_device_model(self):
         return self.json_state.get('manufacturer_device_model')

--- a/src/pywink/devices/binary_switch.py
+++ b/src/pywink/devices/binary_switch.py
@@ -15,14 +15,14 @@ class WinkBinarySwitch(WinkDevice):
         :return: nothing
         """
         values = {"desired_state": {"powered": state}}
-        response = self.api_interface.set_device_state(self, values, type_override="binary_switche")
+        response = self.api_interface.local_set_state(self, values, type_override="binary_switche")
         self._update_state_from_response(response)
 
     def update_state(self):
         """
         Update state with latest info from Wink API.
         """
-        response = self.api_interface.get_device_state(self, type_override="binary_switche")
+        response = self.api_interface.local_get_state(self, type_override="binary_switche")
         return self._update_state_from_response(response)
 
 
@@ -40,8 +40,13 @@ class WinkLeakSmartValve(WinkBinarySwitch):
         :return: nothing
         """
         values = {"desired_state": {"opened": state}}
-        response = self.api_interface.set_device_state(self, values, type_override="binary_switche")
+        response = self.api_interface.local_set_state(self, values, type_override="binary_switche")
         self._update_state_from_response(response)
 
     def last_event(self):
         return self._last_reading.get("last_event")
+
+    def update_state(self):
+        """ Update state with latest info from Wink API. """
+        response = self.api_interface.local_get_state(self)
+        return self._update_state_from_response(response)

--- a/src/pywink/devices/hub.py
+++ b/src/pywink/devices/hub.py
@@ -28,3 +28,6 @@ class WinkHub(WinkDevice):
 
     def firmware_version(self):
         return self._last_reading.get('firmware_version')
+
+    def local_control_id(self):
+        return self._last_reading.get('local_control_id')

--- a/src/pywink/devices/light_bulb.py
+++ b/src/pywink/devices/light_bulb.py
@@ -47,6 +47,11 @@ class WinkLightBulb(WinkDevice):
         """
         return self._last_reading.get('saturation')
 
+    def update_state(self):
+        """ Update state with latest info from Wink API. """
+        response = self.api_interface.local_get_state(self)
+        return self._update_state_from_response(response)
+
     def set_state(self, state, brightness=None,
                   color_kelvin=None, color_xy=None,
                   color_hue_saturation=None):
@@ -72,7 +77,7 @@ class WinkLightBulb(WinkDevice):
         if brightness is not None:
             desired_state.update({'brightness': brightness})
 
-        response = self.api_interface.set_device_state(self, {
+        response = self.api_interface.local_set_state(self, {
             "desired_state": desired_state
         })
         self._update_state_from_response(response)

--- a/src/pywink/devices/lock.py
+++ b/src/pywink/devices/lock.py
@@ -34,7 +34,7 @@ class WinkLock(WinkDevice):
         :return: nothing
         """
         values = {"desired_state": {"alarm_sensitivity": mode}}
-        response = self.api_interface.set_device_state(self, values)
+        response = self.api_interface.local_set_state(self, values)
         self._update_state_from_response(response)
 
     def set_alarm_mode(self, mode):
@@ -43,7 +43,7 @@ class WinkLock(WinkDevice):
         :return: nothing
         """
         values = {"desired_state": {"alarm_mode": mode}}
-        response = self.api_interface.set_device_state(self, values)
+        response = self.api_interface.local_set_state(self, values)
         self._update_state_from_response(response)
 
     def set_alarm_state(self, state):
@@ -52,7 +52,7 @@ class WinkLock(WinkDevice):
         :return: nothing
         """
         values = {"desired_state": {"alarm_enabled": state}}
-        response = self.api_interface.set_device_state(self, values)
+        response = self.api_interface.local_set_state(self, values)
         self._update_state_from_response(response)
 
     def set_vacation_mode(self, state):
@@ -61,7 +61,7 @@ class WinkLock(WinkDevice):
         :return: nothing
         """
         values = {"desired_state": {"vacation_mode_enabled": state}}
-        response = self.api_interface.set_device_state(self, values)
+        response = self.api_interface.local_set_state(self, values)
         self._update_state_from_response(response)
 
     def set_beeper_mode(self, state):
@@ -70,7 +70,7 @@ class WinkLock(WinkDevice):
         :return: nothing
         """
         values = {"desired_state": {"beeper_enabled": state}}
-        response = self.api_interface.set_device_state(self, values)
+        response = self.api_interface.local_set_state(self, values)
         self._update_state_from_response(response)
 
     def set_state(self, state):
@@ -79,5 +79,10 @@ class WinkLock(WinkDevice):
         :return: nothing
         """
         values = {"desired_state": {"locked": state}}
-        response = self.api_interface.set_device_state(self, values)
+        response = self.api_interface.local_set_state(self, values)
         self._update_state_from_response(response)
+
+    def update_state(self):
+        """ Update state with latest info from Wink API. """
+        response = self.api_interface.local_get_state(self)
+        return self._update_state_from_response(response)

--- a/src/pywink/test/__init__.py
+++ b/src/pywink/test/__init__.py
@@ -3,8 +3,7 @@ Top level functions
 """
 # noqa
 from pywink.api import set_bearer_token, refresh_access_token, \
-    set_wink_credentials, set_user_agent, wink_api_fetch, \
-    get_set_access_token, is_token_set, get_devices, \
+    set_wink_credentials, set_user_agent, wink_api_fetch, get_devices, \
     get_subscription_key
 
 from pywink.api import get_light_bulbs, get_garage_doors, get_locks, \

--- a/src/pywink/test/devices/api_responses/home_decorators_light_bulb.json
+++ b/src/pywink/test/devices/api_responses/home_decorators_light_bulb.json
@@ -1,0 +1,81 @@
+{
+  "object_type": "light_bulb",
+  "object_id": "2816576",
+  "uuid": "27ead441-9df5-4068-8880-7c1520880d1d",
+  "icon_id": "71",
+  "icon_code": "light_bulb-light_bulb",
+  "desired_state": {
+    "powered": false,
+    "brightness": 1.0
+  },
+  "last_reading": {
+    "powered": false,
+    "powered_updated_at": 1500756445.3817778,
+    "brightness": 1.0,
+    "brightness_updated_at": 1500756445.3817778,
+    "connection": true,
+    "connection_updated_at": 1500756445.3817778,
+    "firmware_version": "0.0b00 / 0.0b0f",
+    "firmware_version_updated_at": 1500756445.3817778,
+    "firmware_date_code": null,
+    "firmware_date_code_updated_at": null,
+    "desired_powered_updated_at": 1500744848.702631,
+    "desired_brightness_updated_at": 1500744981.9335368,
+    "powered_changed_at": 1500744848.5510266,
+    "brightness_changed_at": 1500136535.6655562,
+    "connection_changed_at": 1500139260.8078806,
+    "firmware_version_changed_at": 1500069548.8840287,
+    "desired_powered_changed_at": 1500744848.702631,
+    "desired_brightness_changed_at": 1500139582.3379252
+  },
+  "subscription": {
+    "pubnub": {
+      "subscribe_key": "sub-c-f7bf7f7e-0542-11e3-a5e8-02ee2ddab7fe",
+      "channel": "fsdjafkljakl;sdjf;lkadsfkl;djasd"
+    }
+  },
+  "light_bulb_id": "2816576",
+  "name": "Dining room fan light",
+  "locale": "en_us",
+  "units": {},
+  "created_at": 1500069521,
+  "hidden_at": null,
+  "capabilities": {
+    "fields": [
+      {
+        "type": "boolean",
+        "field": "powered",
+        "mutability": "read-write"
+      },
+      {
+        "type": "percentage",
+        "field": "brightness",
+        "mutability": "read-write"
+      },
+      {
+        "type": "boolean",
+        "field": "connection",
+        "mutability": "read-only"
+      }
+    ]
+  },
+  "triggers": [],
+  "manufacturer_device_model": "home_decorators_home_decorators_light_bulb",
+  "manufacturer_device_id": null,
+  "device_manufacturer": "home_decorators",
+  "model_name": "Ceiling Fan",
+  "upc_id": "485",
+  "upc_code": "home_decorators_light_bulb",
+  "primary_upc_code": "home_decorators_light_bulb",
+  "gang_id": "91031",
+  "hub_id": "302528",
+  "local_id": "37.2",
+  "radio_type": "zigbee",
+  "linked_service_id": null,
+  "lat_lng": [
+    null,
+    null
+  ],
+  "location": "",
+  "order": 0
+}

--- a/src/pywink/test/devices/base_test.py
+++ b/src/pywink/test/devices/base_test.py
@@ -119,7 +119,7 @@ class BaseTests(unittest.TestCase):
         skip_manufactuer_device_models = ["linear_wadwaz_1",  "linear_wapirz_1", "aeon_labs_dsb45_zwus", "wink_hub", "wink_hub2", "sylvania_sylvania_ct",
                                           "ge_bulb", "quirky_ge_spotter", "schlage_zwave_lock", "home_decorators_home_decorators_fan",
                                           "sylvania_sylvania_rgbw", "somfy_bali", "wink_relay_sensor", "wink_project_one", "kidde_smoke_alarm",
-                                          "wink_relay_switch", "leaksmart_valve"]
+                                          "wink_relay_switch", "leaksmart_valve", "home_decorators_home_decorators_light_bulb"]
         skip_names = ["GoControl Thermostat", "GE Zwave Switch", "New Shortcut", "Test robot"]
         for device in devices:
             if device.name() in skip_names:

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='python-wink',
-      version='1.3.1',
+      version='1.4.0',
       description='Access Wink devices via the Wink API',
       url='http://github.com/python-wink/python-wink',
       author='Brad Johnson',


### PR DESCRIPTION
@pdlove and @appletechy have been doing a ton of work to figure out local control. Turns out it isn't very difficult. @pdlove and @appletechy thanks for all your hard work!  Take a look at their work over here (https://github.com/KraigM/homebridge-wink/wiki/Investigation-of-an-Unofficial-Wink-API)

So I am opening this PR earlier than I normally would because it is going to require a fair amount of change and I would like some import early on.

Some important things to note
- client_id and client_secret are required for this to work
- I believe I have set this up to work for users that have multiple hubs but I don't so I can verify
- The hub uses SSL, but we don't have the cert so when querying the hub SSL verification is disabled ~~An error is output any time the hub is accesses~~This is now suppressed. Should it be?
```
requests-2.13.0-py3.4.egg/requests/packages/urllib3/connectionpool.py:852: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
```
- From my limited testing this doesn't make things much quicker on the v1 hub (but it is local!) haven't tested with a v2 hub to even know if this works. If it does I would expect it to be much quicker.
- The devices controlling hub has a local_control_id, that needs passed to the Wink API to get a new access token that the HUB with accept. Once that token is obtained it can be used for the Wink API and the hub. I am currently only using that new token for the hub. Since details from the hub are required get_hubs() must be called before getting other devices and attempting to set their states.

Local support added for the following (These are the only things listed in my device json from my hub)
- [x] - light bulbs
- [x] - switches
- [x] - locks