### PR TITLE
Wink Aros Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 1.2.3
+- Wink Aros Bugfix
+
 ## 1.2.2
 - Siren inherts from Base device
 

--- a/src/pywink/devices/air_conditioner.py
+++ b/src/pywink/devices/air_conditioner.py
@@ -71,7 +71,7 @@ class WinkAirConditioner(WinkDevice):
 
         self._update_state_from_response(response)
 
-    def set_mode(self, mode):
+    def set_operation_mode(self, mode):
         """
         :param mode: a string one of ["off", "auto_eco", "cool_only", "fan_only"]
         :return: nothing

--- a/src/pywink/test/api_test.py
+++ b/src/pywink/test/api_test.py
@@ -290,7 +290,7 @@ class ApiTests(unittest.TestCase):
         for device in devices:
             device.api_interface = self.api_interface
             old_states[device.object_id()] = device.state()
-            device.set_mode("cool_only")
+            device.set_operation_mode("cool_only")
             device.set_temperature(70)
             device.set_schedule_enabled(False)
             device.set_ac_fan_speed(0.5)

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='python-wink',
-      version='1.2.2',
+      version='1.2.3',
       description='Access Wink devices via the Wink API',
       url='http://github.com/python-wink/python-wink',
       author='Brad Johnson',


### PR DESCRIPTION
Wink Aros set_operation_mode had a typo.  Corrected and tested locally with an Aros Unit.


```
  File "/usr/local/lib/python3.5/dist-packages/homeassistant/components/climate/wink.py", line 417, in set_operation_mode
    self.wink.set_operation_mode('auto_eco')
AttributeError: 'WinkAirConditioner' object has no attribute 'set_operation_mode'
```