### PR TITLE
Fix sirens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 1.2.2
+- Siren inherts from Base device
+
 ## 1.2.1
 - Set default endpoint in wink_api_fetch
 

--- a/src/pywink/devices/siren.py
+++ b/src/pywink/devices/siren.py
@@ -50,3 +50,12 @@ class WinkSiren(WinkBinarySwitch):
         """
         response = self.api_interface.get_device_state(self, type_override="siren")
         return self._update_state_from_response(response)
+
+    def set_state(self, state):
+        """
+        :param state:   a boolean of true (on) or false ('off')
+        :return: nothing
+        """
+        values = {"desired_state": {"powered": state}}
+        response = self.api_interface.set_device_state(self, values, type_override="siren")
+        self._update_state_from_response(response)

--- a/src/pywink/devices/siren.py
+++ b/src/pywink/devices/siren.py
@@ -1,7 +1,7 @@
-from pywink.devices.binary_switch import WinkBinarySwitch
+from pywink.devices.base import WinkDevice
 
 
-class WinkSiren(WinkBinarySwitch):
+class WinkSiren(WinkDevice):
     """
     Represents a Wink Siren.
     """
@@ -48,7 +48,7 @@ class WinkSiren(WinkBinarySwitch):
         """
         Update state with latest info from Wink API.
         """
-        response = self.api_interface.get_device_state(self, type_override="siren")
+        response = self.api_interface.get_device_state(self)
         return self._update_state_from_response(response)
 
     def set_state(self, state):
@@ -57,5 +57,5 @@ class WinkSiren(WinkBinarySwitch):
         :return: nothing
         """
         values = {"desired_state": {"powered": state}}
-        response = self.api_interface.set_device_state(self, values, type_override="siren")
+        response = self.api_interface.set_device_state(self, values)
         self._update_state_from_response(response)

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='python-wink',
-      version='1.2.1',
+      version='1.2.2',
       description='Access Wink devices via the Wink API',
       url='http://github.com/python-wink/python-wink',
       author='Brad Johnson',


### PR DESCRIPTION
Prior to this fix siren updates where going to the binary_switches API endpoint so they wouldn't work.