### PR TITLE
Add get user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 1.2.4
+- Added call to return users account details /users/me
+
 ## 1.2.3
 - Wink Aros Bugfix
 

--- a/src/pywink/__init__.py
+++ b/src/pywink/__init__.py
@@ -5,7 +5,7 @@ Top level functions
 from pywink.api import set_bearer_token, refresh_access_token, \
     set_wink_credentials, set_user_agent, wink_api_fetch, \
     get_set_access_token, is_token_set, get_devices, \
-    get_subscription_key
+    get_subscription_key, get_user
 
 from pywink.api import get_light_bulbs, get_garage_doors, get_locks, \
     get_powerstrips, get_shades, get_sirens, \

--- a/src/pywink/api.py
+++ b/src/pywink/api.py
@@ -133,6 +133,12 @@ def refresh_access_token():
         return None
 
 
+def get_user():
+    url_string = "{}/users/me".format(WinkApiInterface.BASE_URL)
+    arequest = requests.get(url_string, headers=API_HEADERS)
+    return arequest.json()
+
+
 def is_token_set():
     """ Returns if an auth token has been set. """
     return bool(API_HEADERS)

--- a/src/pywink/test/user.json
+++ b/src/pywink/test/user.json
@@ -1,0 +1,62 @@
+{
+   "data":{
+      "user_id":"377857",
+      "first_name":"First",
+      "last_name":"Last",
+      "email":"first.last@wink.com",
+      "locale":"en_us",
+      "units":{
+
+      },
+      "tos_accepted":true,
+      "confirmed":true,
+      "last_reading":{
+         "units":{
+            "temperature":"f"
+         },
+         "units_updated_at":1453091233.737727,
+         "current_location":null,
+         "current_location_updated_at":null,
+         "home_geofence_id":null,
+         "home_geofence_id_updated_at":null,
+         "robot_subscription":null,
+         "robot_subscription_updated_at":null,
+         "current_location_data":null,
+         "current_location_data_updated_at":null,
+         "general_tos_version":"4",
+         "general_tos_version_updated_at":1466634432.1567028,
+         "premium_tos_version":null,
+         "premium_tos_version_updated_at":null,
+         "feature_flags":[
+            "faster_lights"
+         ],
+         "feature_flags_updated_at":1455056917.7954974,
+         "desired_units":null,
+         "desired_units_updated_at":1453091233.7842777,
+         "desired_current_location_updated_at":1453091393.6379838,
+         "desired_home_geofence_id_updated_at":1453091393.6379838,
+         "desired_robot_subscription":null,
+         "desired_robot_subscription_updated_at":null
+      },
+      "created_at":1449441909,
+      "uuid":"5c063d24-4ec0-4076-80ea-97b2252b4f59",
+      "desired_state":{
+         "units":null,
+         "current_location":null,
+         "home_geofence_id":null,
+         "robot_subscription":null
+      },
+      "subscription":{
+         "pubnub":{
+            "subscribe_key":"sub-c-123456789123456789",
+            "channel":"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+         }
+      }
+   },
+   "errors":[
+
+   ],
+   "pagination":{
+
+   }
+}

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='python-wink',
-      version='1.2.3',
+      version='1.2.4',
       description='Access Wink devices via the Wink API',
       url='http://github.com/python-wink/python-wink',
       author='Brad Johnson',


### PR DESCRIPTION
It turns out that a call to /users/me is required in order to keep PubNub subscription updates flowing. This isn't documented anywhere of course. Adding this function so it can be called from HomeAssistant/pubnubsub-handler periodically to keep state changes flowing. 

Waiting to hear back from users here currently testing this before merging. Should hear back soon.

https://community.home-assistant.io/t/ha-stops-reporting-wink-state-changes/5884/550