### PR TITLE
Support for new Wink oauth flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 1.2.5
+- Added functions for auth URL and getting token from code
+
 ## 1.2.4
 - Added call to return users account details /users/me
 

--- a/src/pywink/__init__.py
+++ b/src/pywink/__init__.py
@@ -5,7 +5,8 @@ Top level functions
 from pywink.api import set_bearer_token, refresh_access_token, \
     set_wink_credentials, set_user_agent, wink_api_fetch, \
     get_set_access_token, is_token_set, get_devices, \
-    get_subscription_key, get_user
+    get_subscription_key, get_user, get_authorization_url, \
+    request_token, legacy_set_wink_credentials
 
 from pywink.api import get_light_bulbs, get_garage_doors, get_locks, \
     get_powerstrips, get_shades, get_sirens, \

--- a/src/pywink/devices/air_conditioner.py
+++ b/src/pywink/devices/air_conditioner.py
@@ -7,9 +7,6 @@ class WinkAirConditioner(WinkDevice):
     Represents a Wink air conditioner.
     """
 
-    def __init__(self, device_state_as_json, api_interface):
-        super(WinkAirConditioner, self).__init__(device_state_as_json, api_interface)
-
     def state(self):
         return self.current_mode()
 

--- a/src/pywink/devices/base.py
+++ b/src/pywink/devices/base.py
@@ -42,8 +42,7 @@ class WinkDevice(object):
     def battery_level(self):
         if not self._last_reading.get('external_power'):
             return self._last_reading.get('battery')
-        else:
-            return None
+        return None
 
     def manufacturer_device_model(self):
         return self.json_state.get('manufacturer_device_model')
@@ -66,8 +65,7 @@ class WinkDevice(object):
         if _response_json is not None:
             self.json_state = _response_json
             return True
-        else:
-            return False
+        return False
 
     def update_state(self):
         """ Update state with latest info from Wink API. """

--- a/src/pywink/devices/binary_switch.py
+++ b/src/pywink/devices/binary_switch.py
@@ -6,9 +6,6 @@ class WinkBinarySwitch(WinkDevice):
     Represents a Wink binary switch.
     """
 
-    def __init__(self, device_state_as_json, api_interface):
-        super(WinkBinarySwitch, self).__init__(device_state_as_json, api_interface)
-
     def state(self):
         return self._last_reading.get('powered', False)
 
@@ -33,9 +30,6 @@ class WinkLeakSmartValve(WinkBinarySwitch):
     """
     Represents a Wink leaksmart valve..
     """
-
-    def __init__(self, device_state_as_json, api_interface):
-        super(WinkLeakSmartValve, self).__init__(device_state_as_json, api_interface)
 
     def state(self):
         return self._last_reading.get('opened', False)

--- a/src/pywink/devices/button.py
+++ b/src/pywink/devices/button.py
@@ -6,9 +6,6 @@ class WinkButton(WinkBinarySwitch):
     Represents a Wink relay button.
     """
 
-    def __init__(self, device_state_as_json, api_interface):
-        super(WinkButton, self).__init__(device_state_as_json, api_interface)
-
     def state(self):
         return bool(self.long_pressed() or self.pressed())
 

--- a/src/pywink/devices/camera.py
+++ b/src/pywink/devices/camera.py
@@ -9,9 +9,6 @@ class WinkCanaryCamera(WinkDevice):
     are not listed in the device's JSON.
     """
 
-    def __init__(self, device_state_as_json, api_interface):
-        super(WinkCanaryCamera, self).__init__(device_state_as_json, api_interface)
-
     def state(self):
         return self.mode()
 

--- a/src/pywink/devices/factory.py
+++ b/src/pywink/devices/factory.py
@@ -29,87 +29,79 @@ from pywink.devices.robot import WinkRobot
 from pywink.devices.scene import WinkScene
 
 
-# pylint: disable=redefined-variable-type,too-many-branches, too-many-statements
+# pylint: disable=too-many-branches, too-many-statements
 def build_device(device_state_as_json, api_interface):
-
-    new_object = None
-    new_objects = None
-
-    # These objects all share the same base class: WinkDevice
+    # This is used to determine what type of object to create
     object_type = device_state_as_json.get("object_type")
+    new_objects = []
 
     if object_type == device_types.LIGHT_BULB:
-        new_object = WinkLightBulb(device_state_as_json, api_interface)
+        new_objects.append(WinkLightBulb(device_state_as_json, api_interface))
     elif object_type == device_types.BINARY_SWITCH:
         # Skip relay switches that aren't controlling a load. The binary_switch can't be used.
         if device_state_as_json.get("last_reading").get("powering_mode") is not None:
             mode = device_state_as_json["last_reading"]["powering_mode"]
             if mode == "dumb":
-                new_object = WinkBinarySwitch(device_state_as_json, api_interface)
+                new_objects.append(WinkBinarySwitch(device_state_as_json, api_interface))
         elif device_state_as_json.get("model_name") == "leakSMART Valve":
-            new_object = WinkLeakSmartValve(device_state_as_json, api_interface)
+            new_objects.append(WinkLeakSmartValve(device_state_as_json, api_interface))
         else:
-            new_object = WinkBinarySwitch(device_state_as_json, api_interface)
+            new_objects.append(WinkBinarySwitch(device_state_as_json, api_interface))
     elif object_type == device_types.LOCK:
-        new_object = WinkLock(device_state_as_json, api_interface)
+        new_objects.append(WinkLock(device_state_as_json, api_interface))
     elif object_type == device_types.EGGTRAY:
-        new_object = WinkEggtray(device_state_as_json, api_interface)
+        new_objects.append(WinkEggtray(device_state_as_json, api_interface))
     elif object_type == device_types.GARAGE_DOOR:
-        new_object = WinkGarageDoor(device_state_as_json, api_interface)
+        new_objects.append(WinkGarageDoor(device_state_as_json, api_interface))
     elif object_type == device_types.SHADE:
-        new_object = WinkShade(device_state_as_json, api_interface)
+        new_objects.append(WinkShade(device_state_as_json, api_interface))
     elif object_type == device_types.SIREN:
-        new_object = WinkSiren(device_state_as_json, api_interface)
+        new_objects.append(WinkSiren(device_state_as_json, api_interface))
     elif object_type == device_types.KEY:
-        new_object = WinkKey(device_state_as_json, api_interface)
+        new_objects.append(WinkKey(device_state_as_json, api_interface))
     elif object_type == device_types.THERMOSTAT:
-        new_object = WinkThermostat(device_state_as_json, api_interface)
+        new_objects.append(WinkThermostat(device_state_as_json, api_interface))
     elif object_type == device_types.FAN:
-        new_object = WinkFan(device_state_as_json, api_interface)
+        new_objects.append(WinkFan(device_state_as_json, api_interface))
     elif object_type == device_types.REMOTE:
         # The lutron Pico remote doesn't follow the API spec and
         # provides no benefit as a device in this library.
         if device_state_as_json.get("model_name") != "Pico":
-            new_object = WinkRemote(device_state_as_json, api_interface)
+            new_objects.append(WinkRemote(device_state_as_json, api_interface))
     elif object_type == device_types.HUB:
-        new_object = WinkHub(device_state_as_json, api_interface)
+        new_objects.append(WinkHub(device_state_as_json, api_interface))
     elif object_type == device_types.SENSOR_POD:
-        new_objects = __get_subsensors_from_device(device_state_as_json, api_interface)
+        new_objects.extend(__get_subsensors_from_device(device_state_as_json, api_interface))
     elif object_type == device_types.POWERSTRIP:
-        new_objects = __get_outlets_from_powerstrip(device_state_as_json, api_interface)
+        new_objects.extend(__get_outlets_from_powerstrip(device_state_as_json, api_interface))
         new_objects.append(WinkPowerStrip(device_state_as_json, api_interface))
     elif object_type == device_types.PIGGY_BANK:
-        new_objects = __get_devices_from_piggy_bank(device_state_as_json, api_interface)
+        new_objects.extend(__get_devices_from_piggy_bank(device_state_as_json, api_interface))
     elif object_type == device_types.DOOR_BELL:
-        new_objects = __get_subsensors_from_device(device_state_as_json, api_interface)
+        new_objects.extend(__get_subsensors_from_device(device_state_as_json, api_interface))
     elif object_type == device_types.SPRINKLER:
-        new_object = WinkSprinkler(device_state_as_json, api_interface)
+        new_objects.append(WinkSprinkler(device_state_as_json, api_interface))
     elif object_type == device_types.BUTTON:
-        new_object = WinkButton(device_state_as_json, api_interface)
+        new_objects.append(WinkButton(device_state_as_json, api_interface))
     elif object_type == device_types.GANG:
-        new_object = WinkGang(device_state_as_json, api_interface)
+        new_objects.append(WinkGang(device_state_as_json, api_interface))
     elif object_type == device_types.SMOKE_DETECTOR:
-        new_objects = __get_sensors_from_smoke_detector(device_state_as_json, api_interface)
+        new_objects.extend(__get_sensors_from_smoke_detector(device_state_as_json, api_interface))
     elif object_type == device_types.CAMERA:
         if device_state_as_json.get("device_manufacturer") == "canary":
-            new_object = WinkCanaryCamera(device_state_as_json, api_interface)
+            new_objects.append(WinkCanaryCamera(device_state_as_json, api_interface))
         elif device_state_as_json.get("device_manufacturer") == "dropcam":
-            new_objects = __get_subsensors_from_device(device_state_as_json, api_interface)
+            new_objects.extend(__get_subsensors_from_device(device_state_as_json, api_interface))
     elif object_type == device_types.AIR_CONDITIONER:
-        new_object = WinkAirConditioner(device_state_as_json, api_interface)
+        new_objects.append(WinkAirConditioner(device_state_as_json, api_interface))
     elif object_type == device_types.PROPANE_TANK:
-        new_object = WinkPropaneTank(device_state_as_json, api_interface)
+        new_objects.append(WinkPropaneTank(device_state_as_json, api_interface))
     elif object_type == device_types.ROBOT:
-        new_object = WinkRobot(device_state_as_json, api_interface)
+        new_objects.append(WinkRobot(device_state_as_json, api_interface))
     elif object_type == device_types.SCENE:
-        new_object = WinkScene(device_state_as_json, api_interface)
+        new_objects.append(WinkScene(device_state_as_json, api_interface))
 
-    if new_object is not None:
-        return [new_object]
-    elif new_objects is not None:
-        return new_objects
-    else:
-        return []
+    return new_objects
 
 
 def __get_subsensors_from_device(item, api_interface):

--- a/src/pywink/devices/fan.py
+++ b/src/pywink/devices/fan.py
@@ -8,9 +8,6 @@ class WinkFan(WinkDevice):
     """
     json_state = {}
 
-    def __init__(self, device_state_as_json, api_interface):
-        super(WinkFan, self).__init__(device_state_as_json, api_interface)
-
     def fan_speeds(self):
         capabilities = self.json_state.get('capabilities', {})
         cap_fields = capabilities.get('fields', [])

--- a/src/pywink/devices/garage_door.py
+++ b/src/pywink/devices/garage_door.py
@@ -6,9 +6,6 @@ class WinkGarageDoor(WinkDevice):
     Represents a Wink garage door.
     """
 
-    def __init__(self, device_state_as_json, api_interface):
-        super(WinkGarageDoor, self).__init__(device_state_as_json, api_interface)
-
     def state(self):
         return self._last_reading.get('position', 0)
 

--- a/src/pywink/devices/light_bulb.py
+++ b/src/pywink/devices/light_bulb.py
@@ -9,9 +9,6 @@ class WinkLightBulb(WinkDevice):
     Represents a Wink light bulb.
     """
 
-    def __init__(self, device_state_as_json, api_interface):
-        super(WinkLightBulb, self).__init__(device_state_as_json, api_interface)
-
     def state(self):
         return self._last_reading.get('powered', False)
 

--- a/src/pywink/devices/lock.py
+++ b/src/pywink/devices/lock.py
@@ -6,9 +6,6 @@ class WinkLock(WinkDevice):
     Represents a Wink lock.
     """
 
-    def __init__(self, device_state_as_json, api_interface):
-        super(WinkLock, self).__init__(device_state_as_json, api_interface)
-
     def state(self):
         return self._last_reading.get('locked', False)
 

--- a/src/pywink/devices/powerstrip.py
+++ b/src/pywink/devices/powerstrip.py
@@ -8,9 +8,6 @@ class WinkPowerStrip(WinkDevice):
     Setting the state will set the state of both outlets.
     """
 
-    def __init__(self, device_state_as_json, api_interface):
-        super(WinkPowerStrip, self).__init__(device_state_as_json, api_interface)
-
     def state(self):
         outlets = self.json_state.get('outlets')
         state = False
@@ -34,9 +31,6 @@ class WinkPowerStripOutlet(WinkDevice):
     """
     Represents a Wink Powerstrip outlet.
     """
-
-    def __init__(self, device_state_as_json, api_interface):
-        super(WinkPowerStripOutlet, self).__init__(device_state_as_json, api_interface)
 
     def state(self):
         return self._last_reading.get('powered', False)

--- a/src/pywink/devices/scene.py
+++ b/src/pywink/devices/scene.py
@@ -6,9 +6,6 @@ class WinkScene(WinkDevice):
     Represents a Wink scene.
     """
 
-    def __init__(self, device_state_as_json, api_interface):
-        super(WinkScene, self).__init__(device_state_as_json, api_interface)
-
     def state(self):
         """
         Scenes don't have a state, they can only be triggered.

--- a/src/pywink/devices/shade.py
+++ b/src/pywink/devices/shade.py
@@ -6,9 +6,6 @@ class WinkShade(WinkDevice):
     Represents a Wink Shade.
     """
 
-    def __init__(self, device_state_as_json, api_interface):
-        super(WinkShade, self).__init__(device_state_as_json, api_interface)
-
     def state(self):
         return self._last_reading.get('position', 0)
 

--- a/src/pywink/devices/siren.py
+++ b/src/pywink/devices/siren.py
@@ -6,9 +6,6 @@ class WinkSiren(WinkDevice):
     Represents a Wink Siren.
     """
 
-    def __init__(self, device_state_as_json, api_interface):
-        super(WinkSiren, self).__init__(device_state_as_json, api_interface)
-
     def state(self):
         return self._last_reading.get('powered', False)
 

--- a/src/pywink/devices/sprinkler.py
+++ b/src/pywink/devices/sprinkler.py
@@ -6,9 +6,6 @@ class WinkSprinkler(WinkBinarySwitch):
     Represents a Wink Sprinkler.
     """
 
-    def __init__(self, device_state_as_json, api_interface):
-        super(WinkSprinkler, self).__init__(device_state_as_json, api_interface)
-
     def state(self):
         return self._last_reading.get('powered', False)
 

--- a/src/pywink/devices/thermostat.py
+++ b/src/pywink/devices/thermostat.py
@@ -7,9 +7,6 @@ class WinkThermostat(WinkDevice):
     Represents a Wink thermostat.
     """
 
-    def __init__(self, device_state_as_json, api_interface):
-        super(WinkThermostat, self).__init__(device_state_as_json, api_interface)
-
     def state(self):
         return self.current_hvac_mode()
 

--- a/src/pywink/test/api_test.py
+++ b/src/pywink/test/api_test.py
@@ -1,4 +1,3 @@
-# Standard library imports...
 from http.server import BaseHTTPRequestHandler, HTTPServer
 import json
 import re
@@ -471,3 +470,4 @@ class MockApiInterface():
             if _object_id == object_id:
                 return_dict["data"] = device
         return return_dict
+

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='python-wink',
-      version='1.2.4',
+      version='1.2.5',
       description='Access Wink devices via the Wink API',
       url='http://github.com/python-wink/python-wink',
       author='Brad Johnson',


### PR DESCRIPTION
New client_id and client_secrets obtained from the https://developer.wink.com site don't support the `grant_type: password` in order to use these new client_id and client_secrets users must perform the entire oauth flow and grant their application permission.

At some point in the future the old authentication methods will most likely be removed. 