### PR TITLE
Set user-agent in headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 1.2.6
+- Calling set_user_agent sets the API_HEADERS user_agent
+
 ## 1.2.5
 - Added functions for auth URL and getting token from code
 

--- a/src/pywink/api.py
+++ b/src/pywink/api.py
@@ -86,6 +86,9 @@ def set_user_agent(user_agent):
 
     USER_AGENT = user_agent
 
+    if USER_AGENT:
+        API_HEADERS["User-Agent"] = USER_AGENT
+
 
 def legacy_set_wink_credentials(email, password, client_id, client_secret):
     global CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='python-wink',
-      version='1.2.5',
+      version='1.2.6',
       description='Access Wink devices via the Wink API',
       url='http://github.com/python-wink/python-wink',
       author='Brad Johnson',


### PR DESCRIPTION
Setting the user-agent in the API_HEADERS constant when set_user_agent is called. This allows for changing the user-agent any time which @sibartlett determined keeps the pubnub updates working.