### PR TITLE
Added timeout to local control calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 1.4.1
+- Added timeout to local control calls
+
 ## 1.4.0
 - Local control support for lights, locks, and switches
 

--- a/src/pywink/api.py
+++ b/src/pywink/api.py
@@ -86,10 +86,14 @@ class WinkApiInterface(object):
             url_string = "https://{}:8888/{}s/{}".format(hub["ip"],
                                                          object_type,
                                                          local_id)
-            arequest = requests.put(url_string,
-                                    data=json.dumps(state),
-                                    headers=LOCAL_API_HEADERS,
-                                    verify=False)
+            try:
+                arequest = requests.put(url_string,
+                                        data=json.dumps(state),
+                                        headers=LOCAL_API_HEADERS,
+                                        verify=False, timeout=3)
+            except requests.exceptions.ReadTimeout:
+                _LOGGER.error("Timeout sending local control request. Sending request online")
+                return self.set_device_state(device, state, id_override, type_override)
             response_json = arequest.json()
             _LOGGER.debug(response_json)
             temp_state = device.json_state
@@ -134,9 +138,13 @@ class WinkApiInterface(object):
             url_string = "https://{}:8888/{}s/{}".format(ip,
                                                          object_type,
                                                          local_id)
-            arequest = requests.get(url_string,
-                                    headers=LOCAL_API_HEADERS,
-                                    verify=False)
+            try:
+                arequest = requests.get(url_string,
+                                        headers=LOCAL_API_HEADERS,
+                                        verify=False, timeout=3)
+            except requests.exceptions.ReadTimeout:
+                _LOGGER.error("Timeout sending local control request. Sending request online")
+                return self.get_device_state(device, id_override, type_override)
             response_json = arequest.json()
             _LOGGER.debug(response_json)
             temp_state = device.json_state

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='python-wink',
-      version='1.4.0',
+      version='1.4.1',
       description='Access Wink devices via the Wink API',
       url='http://github.com/python-wink/python-wink',
       author='Brad Johnson',


### PR DESCRIPTION
Managed to get a hub in a strange state yesterday and it stopped accepting local control commands. The request would be made, but would never timeout. Fixed by power cycling my hub, but figured it would be good to account for this.

This adds a timeout to the local control calls of 3 seconds, if the request times out the same request will be sent via the online API.