### PR TITLE
Changed try/except in local control calls to catch all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 1.4.2
+- Changed try/except in local control calls to catch all errors
+
 ## 1.4.1
 - Added timeout to local control calls
 

--- a/src/pywink/api.py
+++ b/src/pywink/api.py
@@ -71,6 +71,7 @@ class WinkApiInterface(object):
         _LOGGER.debug(response_json)
         return response_json
 
+    # pylint: disable=bare-except
     def local_set_state(self, device, state, id_override=None, type_override=None):
         if ALLOW_LOCAL_CONTROL:
             if device.local_id() is not None:
@@ -91,7 +92,7 @@ class WinkApiInterface(object):
                                         data=json.dumps(state),
                                         headers=LOCAL_API_HEADERS,
                                         verify=False, timeout=3)
-            except: 
+            except:
                 _LOGGER.error("Error sending local control request. Sending request online")
                 return self.set_device_state(device, state, id_override, type_override)
             response_json = arequest.json()
@@ -117,6 +118,7 @@ class WinkApiInterface(object):
         _LOGGER.debug(response_json)
         return response_json
 
+    # pylint: disable=bare-except
     def local_get_state(self, device, id_override=None, type_override=None):
         """
         :type device: WinkDevice

--- a/src/pywink/api.py
+++ b/src/pywink/api.py
@@ -91,8 +91,8 @@ class WinkApiInterface(object):
                                         data=json.dumps(state),
                                         headers=LOCAL_API_HEADERS,
                                         verify=False, timeout=3)
-            except requests.exceptions.ReadTimeout:
-                _LOGGER.error("Timeout sending local control request. Sending request online")
+            except: 
+                _LOGGER.error("Error sending local control request. Sending request online")
                 return self.set_device_state(device, state, id_override, type_override)
             response_json = arequest.json()
             _LOGGER.debug(response_json)
@@ -142,8 +142,8 @@ class WinkApiInterface(object):
                 arequest = requests.get(url_string,
                                         headers=LOCAL_API_HEADERS,
                                         verify=False, timeout=3)
-            except requests.exceptions.ReadTimeout:
-                _LOGGER.error("Timeout sending local control request. Sending request online")
+            except:
+                _LOGGER.error("Error sending local control request. Sending request online")
                 return self.get_device_state(device, id_override, type_override)
             response_json = arequest.json()
             _LOGGER.debug(response_json)

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='python-wink',
-      version='1.4.1',
+      version='1.4.2',
       description='Access Wink devices via the Wink API',
       url='http://github.com/python-wink/python-wink',
       author='Brad Johnson',


### PR DESCRIPTION
Since the local control API isn't officially documented there is know way to know what might happen when trying to send requests to the hub. I ran into another issue today where requests were not being sent because the connection was being refused. This didn't happen for long, but does appear to happen every now and then. This change will catch all errors during the local control calls and if anything fails, forward that request online.  