### PR TITLE
Support for hub control and device renaming as well as a fix for empty groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 1.5.0
+- Change device names and hub pairing commands
+
 ## 1.4.2
 - Changed try/except in local control calls to catch all errors
 

--- a/src/pywink/devices/base.py
+++ b/src/pywink/devices/base.py
@@ -23,6 +23,12 @@ class WinkDevice(object):
     def name(self):
         return self.json_state.get('name')
 
+    def set_name(self, name):
+        response = self.api_interface.set_device_state(self, {
+            "name": name
+        })
+        self._update_state_from_response(response)
+
     def state(self):
         raise NotImplementedError("Must implement state")
 

--- a/src/pywink/devices/factory.py
+++ b/src/pywink/devices/factory.py
@@ -103,8 +103,8 @@ def build_device(device_state_as_json, api_interface):
     elif object_type == device_types.SCENE:
         new_objects.append(WinkScene(device_state_as_json, api_interface))
     elif object_type == device_types.GROUP:
-        # This will skip auto created groups that Wink creates.
-        if device_state_as_json.get("name")[0] not in [".", "@"]:
+        # This will skip auto created groups that Wink creates as well has empty groups
+        if device_state_as_json.get("name")[0] not in [".", "@"] and device_state_as_json.get("members"):
             # This is a group of swithces
             if device_state_as_json.get("reading_aggregation").get("brightness") is None:
                 new_objects.append(WinkBinarySwitchGroup(device_state_as_json, api_interface))

--- a/src/pywink/devices/hub.py
+++ b/src/pywink/devices/hub.py
@@ -1,4 +1,10 @@
+import logging
+
 from pywink.devices.base import WinkDevice
+
+import requests
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class WinkHub(WinkDevice):
@@ -31,3 +37,53 @@ class WinkHub(WinkDevice):
 
     def local_control_id(self):
         return self._last_reading.get('local_control_id')
+
+    def pairing_mode(self):
+        return self._last_reading.get('pairing_mode')
+
+    def update_firmware(self):
+        url_string = "{}/{}s/{}/update_firmware".format(self.api_interface.BASE_URL,
+                                                        self.object_type,
+                                                        self.object_id)
+        arequest = requests.post(url_string,
+                                 headers=self.api_interface.API_HEADERS)
+        response_json = arequest.json()
+        return response_json
+
+    def pair_new_device(self, pairing_mode, pairing_mode_duration=60, pairing_device_type_selector=None,
+                        kidde_radio_code=None):
+        """
+        :param pairing_mode: a string one of ["zigbee", "zwave", "zwave_exclusion",
+            "zwave_network_rediscovery", "lutron", "bluetooth", "kidde"]
+        :param pairing_mode_duration: an int in seconds defaults to 60
+        :param pairing_device_type_selector: a string I believe this is only for bluetooth devices.
+        :param kidde_radio_code: a string of 8 1s and 0s one for each dip switch on the kidde device
+            left --> right = 1 --> 8
+        :return: nothing
+        """
+        if pairing_mode == "lutron" and pairing_mode_duration < 120:
+            pairing_mode_duration = 120
+        elif pairing_mode == "zwave_network_rediscovery":
+            pairing_mode_duration = 0
+        elif pairing_mode == "bluetooth" and pairing_device_type_selector is None:
+            pairing_device_type_selector = "switchmate"
+
+        desired_state = {"pairing_mode": pairing_mode,
+                         "pairing_mode_duration": pairing_mode_duration}
+
+        if pairing_mode == "kidde" and kidde_radio_code is not None:
+            # Convert dip switch 1 and 0s to an int
+            try:
+                kidde_radio_code_int = int(kidde_radio_code, 2)
+                desired_state = {"kidde_radio_code": kidde_radio_code_int, "pairing_mode": None}
+            except (TypeError, ValueError):
+                _LOGGER.error("An invalid Kidde radio code was provided. " + kidde_radio_code)
+
+        if pairing_device_type_selector is not None:
+            desired_state.update({"pairing_device_type_selector": pairing_device_type_selector})
+
+        response = self.api_interface.set_device_state(self, {
+            "desired_state": desired_state
+        })
+
+        self._update_state_from_response(response)

--- a/src/pywink/devices/powerstrip.py
+++ b/src/pywink/devices/powerstrip.py
@@ -74,6 +74,15 @@ class WinkPowerStripOutlet(WinkDevice):
     def parent_object_type(self):
         return self.json_state.get('parent_object_type')
 
+    def set_name(self, name):
+        if self.index() == 0:
+            values = {"outlets": [{"name": name}, {}]}
+        else:
+            values = {"outlets": [{}, {"name": name}]}
+        response = self.api_interface.set_device_state(self, values, id_override=self.parent_id(),
+                                                       type_override="powerstrip")
+        self._update_state_from_response(response)
+
     def set_state(self, state):
         """
         :param state:   a boolean of true (on) or false ('off')

--- a/src/pywink/devices/scene.py
+++ b/src/pywink/devices/scene.py
@@ -26,9 +26,3 @@ class WinkScene(WinkDevice):
         """
         response = self.api_interface.set_device_state(self, None)
         self._update_state_from_response(response)
-
-    def update_state(self):
-        """
-        Nothing changes in the JSON state of this device.
-        """
-        return True

--- a/src/pywink/test/api_test.py
+++ b/src/pywink/test/api_test.py
@@ -483,6 +483,16 @@ class ApiTests(unittest.TestCase):
             device.update_state()
         self.assertEqual(device.tare(), 5.0)
 
+    def test_set_all_device_names(self):
+        WinkApiInterface.BASE_URL = "http://localhost:" + str(self.port)
+        devices = get_all_devices()
+        old_states = {}
+        for device in devices:
+            device.api_interface = self.api_interface
+            device.set_name("TEST_NAME")
+            device.update_state()
+        for device in devices:
+            self.assertTrue(device.name().startswith("TEST_NAME"))
 
 
 class MockServerRequestHandler(BaseHTTPRequestHandler):
@@ -563,7 +573,22 @@ class MockApiInterface():
         device_object_type = device.object_type()
         object_type = type_override or device_object_type
         return_dict = {}
-        if object_type != "group":
+        if "name" in str(state):
+            for dict_device in USERS_ME_WINK_DEVICES.get('data'):
+                _object_id = dict_device.get("object_id")
+                if _object_id == object_id:
+                    if device_object_type == "outlet":
+                        index = device.index()
+                        set_state = state["outlets"][index]["name"]
+                        dict_device["outlets"][index]["name"] = set_state
+                        return_dict["data"] = dict_device
+                    else:
+                        dict_device["name"] = state.get("name")
+            for dict_device in GROUPS.get('data'):
+                _object_id = dict_device.get("object_id")
+                if _object_id == object_id:
+                    dict_device["name"] = state.get("name")
+        elif object_type != "group":
             for dict_device in USERS_ME_WINK_DEVICES.get('data'):
                 _object_id = dict_device.get("object_id")
                 if _object_id == object_id:

--- a/src/pywink/test/devices/api_responses/groups/empty_user_group.json
+++ b/src/pywink/test/devices/api_responses/groups/empty_user_group.json
@@ -1,0 +1,19 @@
+{
+  "group_id": "2086633",
+  "name": "Living Room front",
+  "order": 0,
+  "icon_id": "28",
+  "members": [],
+  "reading_aggregation": {},
+  "automation_mode": null,
+  "hidden_at": null,
+  "object_type": "group",
+  "object_id": "2086633",
+  "icon_code": "group-light_group",
+  "subscription": {
+    "pubnub": {
+      "subscribe_key": "sub-c-f7bf7f7e-0542-11edfadfadgdage2ddab7fe",
+      "channel": "jkasdjfa8r390uq4jasdfkljasd09i834"
+    }
+  }
+}

--- a/src/pywink/test/devices/scene_test.py
+++ b/src/pywink/test/devices/scene_test.py
@@ -20,15 +20,6 @@ class SceneTests(unittest.TestCase):
         scene = devices[0]
         self.assertFalse(scene.state())
 
-    def test_update_state_should_be_true(self):
-        with open('{}/api_responses/scene.json'.format(os.path.dirname(__file__))) as scene_file:
-            response_dict = json.load(scene_file)
-        response_dict = {"data": [response_dict]}
-        devices = get_devices_from_response_dict(response_dict, device_types.SCENE)
-
-        scene = devices[0]
-        self.assertTrue(scene.update_state())
-
     def test_available_should_be_true(self):
         with open('{}/api_responses/scene.json'.format(os.path.dirname(__file__))) as scene_file:
             response_dict = json.load(scene_file)

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='python-wink',
-      version='1.4.2',
+      version='1.5.0',
       description='Access Wink devices via the Wink API',
       url='http://github.com/python-wink/python-wink',
       author='Brad Johnson',


### PR DESCRIPTION
Did a little messing around with the official Wink app and figured out how they are sending device pairing commands as well as device renaming.

This will allow users to pair new devices Zwave, ZigBee, Lutron, Bluetooth, and Kidde by calling pair_new_device with the correct radio type. Other than Bluetooth, the hub determines the device type/functions automatically. The same call can be made to perform specific Zwave functions like exclusion mode. 

Since there is only one support Bluetooth device with Wink at the moment Bluetooths pairing_device_type_selector defaults to `switchmate`.

I am assuming when new devices get added there will be multiple pairing_device_type_selector's 

This also fixes a rare issue where users have light or switch groups that don't have any devices in them. One user reported an error from this, and couldn't have these groups in the Wink App, they had to be deleted from Wink@Home.

I have personally only tested pairing ZigBee device, but I have issued Zwave, and Lutron and con confirm they put the Hub in pairing mode. 

**Note: The only devices that can't be connected are Quirky devices because they require the use of a phone screen to "flash" the auth/connection details to the device.