### PR TITLE
Fixed setting extended lock features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.7.1
+- Extended lock feature can't be performed via local control. Set with online.
+- Cleaned up imports/tests/style
+
 ## 1.7.0
 - Thermostat fixes for away mode.
 - Support for Dome Siren/Chime
@@ -44,7 +48,7 @@
 - Wink Aros Bugfix
 
 ## 1.2.2
-- Siren inherts from Base device
+- Siren inherits from Base device
 
 ## 1.2.1
 - Set default endpoint in wink_api_fetch
@@ -53,7 +57,7 @@
 - Robot and Scene support
 
 ## 1.1.1
-- Bugfix for lutron lights missing object_id and object_type
+- Bugfix for Lutron lights missing object_id and object_type
 
 ## 1.1.0
 - Support for Quirky Aros AC units
@@ -62,7 +66,7 @@
 - Fix for leaksmart valves
 
 ## 1.0.0
-- Switch to object_type for device type detction
+- Switch to object_type for device type detection
 - Hard coded user agent
 - Support for Lutron connected bulb remotes
 - Support for Sprinklers
@@ -121,7 +125,7 @@
 - Added Wink keys (Wink Lock user codes)
 
 ## 0.7.8
-- Added support for retrieving the Pubnub subscription details
+- Added support for retrieving the PubNub subscription details
 
 ## 0.7.7
 - Stopped duplicating door switches in `get_devices_from_response_dict`

--- a/src/pywink/api.py
+++ b/src/pywink/api.py
@@ -116,7 +116,7 @@ class WinkApiInterface(object):
                                         data=json.dumps(state),
                                         headers=LOCAL_API_HEADERS,
                                         verify=False, timeout=3)
-            except:
+            except requests.exceptions.RequestException:
                 _LOGGER.error("Error sending local control request. Sending request online")
                 return self.set_device_state(device, state, id_override, type_override)
             response_json = arequest.json()
@@ -188,7 +188,7 @@ class WinkApiInterface(object):
                 arequest = requests.get(url_string,
                                         headers=LOCAL_API_HEADERS,
                                         verify=False, timeout=3)
-            except:
+            except requests.exceptions.RequestException:
                 _LOGGER.error("Error sending local control request. Sending request online")
                 return self.get_device_state(device, id_override, type_override)
             response_json = arequest.json()
@@ -220,10 +220,13 @@ class WinkApiInterface(object):
         url_string = "{}/{}s/{}/update_firmware".format(self.BASE_URL,
                                                         object_type,
                                                         object_id)
-        arequest = requests.post(url_string,
-                                 headers=API_HEADERS)
-        response_json = arequest.json()
-        return response_json
+        try:
+            arequest = requests.post(url_string,
+                                     headers=API_HEADERS)
+            response_json = arequest.json()
+            return response_json
+        except requests.exceptions.RequestException:
+            return None
 
     def remove_device(self, device, id_override=None, type_override=None):
         """
@@ -244,12 +247,16 @@ class WinkApiInterface(object):
         url_string = "{}/{}s/{}".format(self.BASE_URL,
                                         object_type,
                                         object_id)
-        arequest = requests.delete(url_string,
-                                   headers=API_HEADERS)
-        if arequest.status_code == 204:
-            return True
-        _LOGGER.error("Failed to remove device. Status code: " + arequest.status_code)
-        return False
+        try:
+            arequest = requests.delete(url_string,
+                                       headers=API_HEADERS)
+            if arequest.status_code == 204:
+                return True
+            _LOGGER.error("Failed to remove device. Status code: " + arequest.status_code)
+            return False
+        except requests.exceptions.RequestException:
+            _LOGGER.error("Failed to remove device. Status code: " + arequest.status_code)
+            return False
 
     def create_lock_key(self, device, new_device_json, id_override=None, type_override=None):
         """
@@ -271,11 +278,14 @@ class WinkApiInterface(object):
         url_string = "{}/{}s/{}/keys".format(self.BASE_URL,
                                              object_type,
                                              object_id)
-        arequest = requests.post(url_string,
-                                 data=json.dumps(new_device_json),
-                                 headers=API_HEADERS)
-        response_json = arequest.json()
-        return response_json
+        try:
+            arequest = requests.post(url_string,
+                                     data=json.dumps(new_device_json),
+                                     headers=API_HEADERS)
+            response_json = arequest.json()
+            return response_json
+        except requests.exceptions.RequestException:
+            return None
 
 
 def disable_local_control():

--- a/src/pywink/api.py
+++ b/src/pywink/api.py
@@ -159,7 +159,6 @@ class WinkApiInterface(object):
 
         Args:
             device (WinkDevice): The device the change is being requested for.
-            state (Dict): The state being requested.
             id_override (String, optional): A device ID used to override the
                 passed in device's ID. Used to make changes on sub-devices.
                 i.e. Outlet in a Powerstrip. The Parent device's ID.

--- a/src/pywink/api.py
+++ b/src/pywink/api.py
@@ -562,8 +562,11 @@ def get_binary_switch_groups():
 
 def get_subscription_key():
     response_dict = wink_api_fetch()
-    first_device = response_dict.get('data')[0]
-    return get_subscription_key_from_response_dict(first_device)
+    try:
+        first_device = response_dict.get('data')[0]
+        return get_subscription_key_from_response_dict(first_device)
+    except IndexError:
+        raise WinkAPIException("No Wink devices associated with account.")
 
 
 def get_subscription_key_from_response_dict(device):
@@ -578,7 +581,6 @@ def wink_api_fetch(end_point='wink_devices'):
     _LOGGER.debug(response)
     if response.status_code == 200:
         return response.json()
-
     if response.status_code == 401:
         raise WinkAPIException("401 Response from Wink API.  Maybe Bearer token is expired?")
     else:

--- a/src/pywink/devices/air_conditioner.py
+++ b/src/pywink/devices/air_conditioner.py
@@ -86,7 +86,7 @@ class WinkAirConditioner(WinkDevice):
 
     def set_temperature(self, max_set_point=None):
         """
-        :param temperature: a float for the temperature value in celsius
+        :param max_set_point: a float for the max set point value in celsius
         :return: nothing
         """
         desired_state = {}

--- a/src/pywink/devices/factory.py
+++ b/src/pywink/devices/factory.py
@@ -147,16 +147,13 @@ def __get_outlets_from_powerstrip(item, api_interface):
 
 
 def __get_devices_from_piggy_bank(item, api_interface):
-    subdevices = []
-    subdevices.append(WinkPorkfolioBalanceSensor(item, api_interface))
-    subdevices.append(WinkPorkfolioNose(item, api_interface))
-    return subdevices
+    return [WinkPorkfolioBalanceSensor(item, api_interface),
+            WinkPorkfolioNose(item, api_interface)]
 
 
 def __get_sensors_from_smoke_detector(item, api_interface):
-    sensors = []
-    sensors.append(WinkSmokeDetector(item, api_interface))
-    sensors.append(WinkCoDetector(item, api_interface))
+    sensors = [WinkSmokeDetector(item, api_interface),
+               WinkCoDetector(item, api_interface)]
     if item.get("manufacturer_device_model") == "nest":
         sensors.append(WinkSmokeSeverity(item, api_interface))
         sensors.append(WinkCoSeverity(item, api_interface))

--- a/src/pywink/devices/fan.py
+++ b/src/pywink/devices/fan.py
@@ -52,7 +52,7 @@ class WinkFan(WinkDevice):
 
     def set_state(self, state, speed=None):
         """
-        :param powered: bool
+        :param state: bool
         :param speed: a string one of ["lowest", "low",
             "medium", "high", "auto"] defaults to last speed
         :return: nothing
@@ -71,7 +71,7 @@ class WinkFan(WinkDevice):
 
     def set_fan_direction(self, direction):
         """
-        :param speed: a string one of ["forward", "reverse"]
+        :param direction: a string one of ["forward", "reverse"]
         :return: nothing
         """
         desired_state = {"direction": direction}

--- a/src/pywink/devices/light_bulb.py
+++ b/src/pywink/devices/light_bulb.py
@@ -162,4 +162,4 @@ def _format_xy(xy):
 def _get_color_as_hue_saturation_brightness(hue_sat):
     if hue_sat:
         color_hs_iter = iter(hue_sat)
-        return (next(color_hs_iter), next(color_hs_iter), 1)
+        return next(color_hs_iter), next(color_hs_iter), 1

--- a/src/pywink/devices/lock.py
+++ b/src/pywink/devices/lock.py
@@ -34,7 +34,7 @@ class WinkLock(WinkDevice):
         :return: nothing
         """
         values = {"desired_state": {"alarm_sensitivity": mode}}
-        response = self.api_interface.local_set_state(self, values)
+        response = self.api_interface.set_device_state(self, values)
         self._update_state_from_response(response)
 
     def set_alarm_mode(self, mode):
@@ -43,7 +43,7 @@ class WinkLock(WinkDevice):
         :return: nothing
         """
         values = {"desired_state": {"alarm_mode": mode}}
-        response = self.api_interface.local_set_state(self, values)
+        response = self.api_interface.set_device_state(self, values)
         self._update_state_from_response(response)
 
     def set_alarm_state(self, state):
@@ -52,7 +52,7 @@ class WinkLock(WinkDevice):
         :return: nothing
         """
         values = {"desired_state": {"alarm_enabled": state}}
-        response = self.api_interface.local_set_state(self, values)
+        response = self.api_interface.set_device_state(self, values)
         self._update_state_from_response(response)
 
     def set_vacation_mode(self, state):
@@ -61,7 +61,7 @@ class WinkLock(WinkDevice):
         :return: nothing
         """
         values = {"desired_state": {"vacation_mode_enabled": state}}
-        response = self.api_interface.local_set_state(self, values)
+        response = self.api_interface.set_device_state(self, values)
         self._update_state_from_response(response)
 
     def set_beeper_mode(self, state):
@@ -70,7 +70,7 @@ class WinkLock(WinkDevice):
         :return: nothing
         """
         values = {"desired_state": {"beeper_enabled": state}}
-        response = self.api_interface.local_set_state(self, values)
+        response = self.api_interface.set_device_state(self, values)
         self._update_state_from_response(response)
 
     def set_state(self, state):
@@ -83,7 +83,7 @@ class WinkLock(WinkDevice):
         self._update_state_from_response(response)
 
     def update_state(self):
-        """ Update state with latest info from Wink API. """
+        """Update state with latest info from Wink API."""
         response = self.api_interface.local_get_state(self)
         return self._update_state_from_response(response)
 

--- a/src/pywink/devices/piggy_bank.py
+++ b/src/pywink/devices/piggy_bank.py
@@ -21,7 +21,7 @@ class WinkPorkfolioNose(WinkDevice):
 
     def set_state(self, color_hex):
         """
-        :param nose_color: a hex string indicating the color of the porkfolio nose
+        :param color_hex: a hex string indicating the color of the porkfolio nose
         :return: nothing
         From the api...
         "the color of the nose is not in the desired_state

--- a/src/pywink/devices/siren.py
+++ b/src/pywink/devices/siren.py
@@ -119,6 +119,7 @@ class WinkSiren(WinkDevice):
         :param sound: a str, one of ["doorbell", "fur_elise", "doorbell_extended", "alert",
                                      "william_tell", "rondo_alla_turca", "police_siren",
                                      ""evacuation", "beep_beep", "beep", "inactive"]
+        :param cycles: Undocumented seems to have no effect?
         :return: nothing
         """
         desired_state = {"activate_chime": sound}
@@ -130,7 +131,7 @@ class WinkSiren(WinkDevice):
 
     def set_auto_shutoff(self, timer):
         """
-        :param time: an int, one of [None (never), -1, 30, 60, 120]
+        :param timer: an int, one of [None (never), -1, 30, 60, 120]
         :return: nothing
         """
         values = {

--- a/src/pywink/devices/thermostat.py
+++ b/src/pywink/devices/thermostat.py
@@ -177,7 +177,8 @@ class WinkThermostat(WinkDevice):
 
     def set_temperature(self, min_set_point=None, max_set_point=None):
         """
-        :param temperature: a float for the temperature value in celsius
+        :param min_set_point: a float for the min set point value in celsius
+        :param max_set_point: a float for the max set point value in celsius
         :return: nothing
         """
         desired_state = {}

--- a/src/pywink/devices/water_heater.py
+++ b/src/pywink/devices/water_heater.py
@@ -52,7 +52,7 @@ class WinkWaterHeater(WinkDevice):
 
     def set_temperature(self, set_point):
         """
-        :param temperature: a float for the temperature value in celsius
+        :param set_point: a float for the set point value in celsius
         :return: nothing
         """
         response = self.api_interface.set_device_state(self, {

--- a/src/pywink/test/api_test.py
+++ b/src/pywink/test/api_test.py
@@ -1,5 +1,4 @@
 from http.server import BaseHTTPRequestHandler, HTTPServer
-import json
 import re
 import socket
 from threading import Thread
@@ -7,12 +6,9 @@ import unittest
 import os
 
 # Third-party imports...
-import requests
-from mock import patch
 from unittest.mock import MagicMock, Mock
 
 from pywink.api import *
-from pywink.devices import types as device_types
 from pywink.api import WinkApiInterface
 from pywink.devices.sensor import WinkSensor
 from pywink.devices.hub import WinkHub
@@ -32,7 +28,6 @@ from pywink.devices.thermostat import WinkThermostat
 from pywink.devices.button import WinkButton
 from pywink.devices.gang import WinkGang
 from pywink.devices.smoke_detector import WinkSmokeDetector, WinkSmokeSeverity, WinkCoDetector, WinkCoSeverity
-from pywink.devices.sprinkler import WinkSprinkler
 from pywink.devices.camera import WinkCanaryCamera
 from pywink.devices.air_conditioner import WinkAirConditioner
 from pywink.devices.propane_tank import WinkPropaneTank
@@ -45,7 +40,6 @@ GROUPS = {}
 
 
 class ApiTests(unittest.TestCase):
-
 
     def setUp(self):
         global USERS_ME_WINK_DEVICES, GROUPS

--- a/src/pywink/test/devices/air_conditioner_test.py
+++ b/src/pywink/test/devices/air_conditioner_test.py
@@ -2,18 +2,17 @@ import json
 import os
 import unittest
 
-import mock
+from unittest.mock import MagicMock
 
-from pywink.api import get_devices_from_response_dict, WinkApiInterface
+from pywink.api import get_devices_from_response_dict
 from pywink.devices import types as device_types
-from pywink.devices.air_conditioner import WinkAirConditioner
 
 
 class AirConditionerTests(unittest.TestCase):
 
     def setUp(self):
         super(AirConditionerTests, self).setUp()
-        self.api_interface = mock.MagicMock()
+        self.api_interface = MagicMock()
 
     def test_ac_state(self):
         device_list = []

--- a/src/pywink/test/devices/base_test.py
+++ b/src/pywink/test/devices/base_test.py
@@ -2,9 +2,9 @@ import json
 import os
 import unittest
 
-import mock
+from unittest.mock import MagicMock
 
-from pywink.api import get_devices_from_response_dict, WinkApiInterface
+from pywink.api import get_devices_from_response_dict
 from pywink.devices import types as device_types
 from pywink.devices.key import WinkKey
 from pywink.devices.powerstrip import WinkPowerStripOutlet, WinkPowerStrip
@@ -33,7 +33,7 @@ class BaseTests(unittest.TestCase):
 
     def setUp(self):
         super(BaseTests, self).setUp()
-        self.api_interface = mock.MagicMock()
+        self.api_interface = MagicMock()
         all_devices = os.listdir('{}/api_responses/'.format(os.path.dirname(__file__)))
         self.response_dict = {}
         device_list = []

--- a/src/pywink/test/devices/fan_test.py
+++ b/src/pywink/test/devices/fan_test.py
@@ -2,18 +2,17 @@ import json
 import os
 import unittest
 
-import mock
+from unittest.mock import MagicMock
 
-from pywink.api import get_devices_from_response_dict, WinkApiInterface
+from pywink.api import get_devices_from_response_dict
 from pywink.devices import types as device_types
-from pywink.devices.fan import WinkFan
 
 
 class FanTests(unittest.TestCase):
 
     def setUp(self):
         super(FanTests, self).setUp()
-        self.api_interface = mock.MagicMock()
+        self.api_interface = MagicMock()
         device_list = []
         self.response_dict = {}
         _json_file = open('{}/api_responses/fan.json'.format(os.path.dirname(__file__)))

--- a/src/pywink/test/devices/garage_door_test.py
+++ b/src/pywink/test/devices/garage_door_test.py
@@ -2,18 +2,17 @@ import json
 import os
 import unittest
 
-import mock
+from unittest.mock import MagicMock
 
-from pywink.api import get_devices_from_response_dict, WinkApiInterface
+from pywink.api import get_devices_from_response_dict
 from pywink.devices import types as device_types
-from pywink.devices.garage_door import WinkGarageDoor
 
 
 class GarageDoorTests(unittest.TestCase):
 
     def setUp(self):
         super(GarageDoorTests, self).setUp()
-        self.api_interface = mock.MagicMock()
+        self.api_interface = MagicMock()
         all_devices = os.listdir('{}/api_responses/'.format(os.path.dirname(__file__)))
         self.response_dict = {}
         device_list = []

--- a/src/pywink/test/devices/hub_test.py
+++ b/src/pywink/test/devices/hub_test.py
@@ -2,18 +2,17 @@ import json
 import os
 import unittest
 
-import mock
+from unittest.mock import MagicMock
 
-from pywink.api import get_devices_from_response_dict, WinkApiInterface
+from pywink.api import get_devices_from_response_dict
 from pywink.devices import types as device_types
-from pywink.devices.hub import WinkHub
 
 
 class HubTests(unittest.TestCase):
 
     def setUp(self):
         super(HubTests, self).setUp()
-        self.api_interface = mock.MagicMock()
+        self.api_interface = MagicMock()
         all_devices = os.listdir('{}/api_responses/'.format(os.path.dirname(__file__)))
         self.response_dict = {}
         device_list = []

--- a/src/pywink/test/devices/light_bulb_test.py
+++ b/src/pywink/test/devices/light_bulb_test.py
@@ -2,11 +2,10 @@ import json
 import os
 import unittest
 
-import mock
+from unittest.mock import MagicMock
 
-from pywink.api import get_devices_from_response_dict, WinkApiInterface
+from pywink.api import get_devices_from_response_dict
 from pywink.devices import types as device_types
-from pywink.devices.light_bulb import WinkLightBulb
 from pywink.devices.light_group import WinkLightGroup
 
 JSON_DATA = {}
@@ -16,7 +15,7 @@ class LightBulbTests(unittest.TestCase):
 
     def setUp(self):
         super(LightBulbTests, self).setUp()
-        self.api_interface = mock.MagicMock()
+        self.api_interface = MagicMock()
 
     def test_bulb_brightness(self):
         device_list = []

--- a/src/pywink/test/devices/lock_test.py
+++ b/src/pywink/test/devices/lock_test.py
@@ -2,9 +2,9 @@ import json
 import os
 import unittest
 
-import mock
+from unittest.mock import MagicMock
 
-from pywink.api import get_devices_from_response_dict, WinkApiInterface
+from pywink.api import get_devices_from_response_dict
 from pywink.devices import types as device_types
 
 
@@ -12,7 +12,7 @@ class LockTests(unittest.TestCase):
 
     def setUp(self):
         super(LockTests, self).setUp()
-        self.api_interface = mock.MagicMock()
+        self.api_interface = MagicMock()
         device_list = []
         self.response_dict = {}
         _json_file = open('{}/api_responses/schlage_lock.json'.format(os.path.dirname(__file__)))

--- a/src/pywink/test/devices/powerstrip_test.py
+++ b/src/pywink/test/devices/powerstrip_test.py
@@ -2,11 +2,8 @@ import json
 import os
 import unittest
 
-import mock
-
-from pywink.api import get_devices_from_response_dict, WinkApiInterface
+from pywink.api import get_devices_from_response_dict
 from pywink.devices import types as device_types
-from pywink.devices.powerstrip import WinkPowerStrip, WinkPowerStripOutlet
 
 
 class PowerstripTests(unittest.TestCase):
@@ -45,7 +42,6 @@ class PowerstripTests(unittest.TestCase):
         devices = get_devices_from_response_dict(response_dict, device_types.POWERSTRIP)
 
         self.assertEqual(len(devices), 3)
-        powerstrip = devices[-1]
         outlet_1 = devices[0]
         outlet_2 = devices[1]
         self.assertEqual(0, outlet_1.index())

--- a/src/pywink/test/devices/scene_test.py
+++ b/src/pywink/test/devices/scene_test.py
@@ -2,11 +2,8 @@ import json
 import os
 import unittest
 
-import mock
-
-from pywink.api import get_devices_from_response_dict, WinkApiInterface
+from pywink.api import get_devices_from_response_dict
 from pywink.devices import types as device_types
-from pywink.devices.scene import WinkScene
 
 
 class SceneTests(unittest.TestCase):

--- a/src/pywink/test/devices/sensor_test.py
+++ b/src/pywink/test/devices/sensor_test.py
@@ -2,20 +2,19 @@ import json
 import os
 import unittest
 
-import mock
+from unittest.mock import MagicMock
 
-from pywink.api import get_devices_from_response_dict, WinkApiInterface
+from pywink.api import get_devices_from_response_dict
 from pywink.devices import types as device_types
-from pywink.devices.sensor import WinkSensor
 from pywink.devices.piggy_bank import WinkPorkfolioBalanceSensor
 from pywink.devices.smoke_detector import WinkSmokeDetector, WinkCoDetector, WinkSmokeSeverity, WinkCoSeverity
-from pywink.devices.propane_tank import WinkPropaneTank
+
 
 class SensorTests(unittest.TestCase):
 
     def setUp(self):
         super(SensorTests, self).setUp()
-        self.api_interface = mock.MagicMock()
+        self.api_interface = MagicMock()
         all_devices = os.listdir('{}/api_responses/'.format(os.path.dirname(__file__)))
         self.response_dict = {}
         device_list = []
@@ -49,7 +48,7 @@ class EggtrayTests(unittest.TestCase):
 
     def setUp(self):
         super(EggtrayTests, self).setUp()
-        self.api_interface = mock.MagicMock()
+        self.api_interface = MagicMock()
         all_devices = os.listdir('{}/api_responses/'.format(os.path.dirname(__file__)))
         self.response_dict = {}
         device_list = []
@@ -75,11 +74,12 @@ class EggtrayTests(unittest.TestCase):
         for device in devices:
             self.assertEqual(device.unit(), "eggs")
 
+
 class KeyTests(unittest.TestCase):
 
     def setUp(self):
         super(KeyTests, self).setUp()
-        self.api_interface = mock.MagicMock()
+        self.api_interface = MagicMock()
         all_devices = os.listdir('{}/api_responses/'.format(os.path.dirname(__file__)))
         self.response_dict = {}
         device_list = []
@@ -116,11 +116,12 @@ class KeyTests(unittest.TestCase):
         for device in devices:
             self.assertIsNone(device.unit())
 
+
 class PorkfolioTests(unittest.TestCase):
 
     def setUp(self):
         super(PorkfolioTests, self).setUp()
-        self.api_interface = mock.MagicMock()
+        self.api_interface = MagicMock()
         all_devices = os.listdir('{}/api_responses/'.format(os.path.dirname(__file__)))
         self.response_dict = {}
         device_list = []
@@ -156,11 +157,12 @@ class PorkfolioTests(unittest.TestCase):
             if isinstance(device, WinkPorkfolioBalanceSensor):
                 self.assertTrue(device.available())
 
+
 class GangTests(unittest.TestCase):
 
     def setUp(self):
         super(GangTests, self).setUp()
-        self.api_interface = mock.MagicMock()
+        self.api_interface = MagicMock()
         all_devices = os.listdir('{}/api_responses/'.format(os.path.dirname(__file__)))
         self.response_dict = {}
         device_list = []
@@ -176,11 +178,12 @@ class GangTests(unittest.TestCase):
         for device in devices:
             self.assertIsNone(device.unit())
 
+
 class SmokeDetectorTests(unittest.TestCase):
 
     def setUp(self):
         super(SmokeDetectorTests, self).setUp()
-        self.api_interface = mock.MagicMock()
+        self.api_interface = MagicMock()
         all_devices = os.listdir('{}/api_responses/'.format(os.path.dirname(__file__)))
         self.response_dict = {}
         device_list = []
@@ -217,7 +220,7 @@ class RemoteTests(unittest.TestCase):
 
     def setUp(self):
         super(RemoteTests, self).setUp()
-        self.api_interface = mock.MagicMock()
+        self.api_interface = MagicMock()
         all_devices = os.listdir('{}/api_responses/'.format(os.path.dirname(__file__)))
         self.response_dict = {}
         device_list = []
@@ -247,7 +250,7 @@ class PropaneTankTests(unittest.TestCase):
 
     def setUp(self):
         super(PropaneTankTests, self).setUp()
-        self.api_interface = mock.MagicMock()
+        self.api_interface = MagicMock()
         all_devices = os.listdir('{}/api_responses/'.format(os.path.dirname(__file__)))
         self.response_dict = {}
         device_list = []

--- a/src/pywink/test/devices/siren_test.py
+++ b/src/pywink/test/devices/siren_test.py
@@ -2,9 +2,9 @@ import json
 import os
 import unittest
 
-import mock
+from unittest.mock import MagicMock
 
-from pywink.api import get_devices_from_response_dict, WinkApiInterface
+from pywink.api import get_devices_from_response_dict
 from pywink.devices import types as device_types
 
 
@@ -12,7 +12,7 @@ class SirenTests(unittest.TestCase):
 
     def setUp(self):
         super(SirenTests, self).setUp()
-        self.api_interface = mock.MagicMock()
+        self.api_interface = MagicMock()
         device_list = []
         self.response_dict = {}
         _json_file = open('{}/api_responses/go_control_siren.json'.format(os.path.dirname(__file__)))

--- a/src/pywink/test/devices/switch_test.py
+++ b/src/pywink/test/devices/switch_test.py
@@ -2,11 +2,8 @@ import json
 import os
 import unittest
 
-import mock
-
-from pywink.api import get_devices_from_response_dict, WinkApiInterface
+from pywink.api import get_devices_from_response_dict
 from pywink.devices import types as device_types
-from pywink.devices.binary_switch import WinkBinarySwitch
 from pywink.devices.binary_switch_group import WinkBinarySwitchGroup
 
 JSON_DATA = {}

--- a/src/pywink/test/devices/thermostat_test.py
+++ b/src/pywink/test/devices/thermostat_test.py
@@ -2,18 +2,17 @@ import json
 import os
 import unittest
 
-import mock
+from unittest.mock import MagicMock
 
-from pywink.api import get_devices_from_response_dict, WinkApiInterface
+from pywink.api import get_devices_from_response_dict
 from pywink.devices import types as device_types
-from pywink.devices.thermostat import WinkThermostat
 
 
 class ThermostatTests(unittest.TestCase):
 
     def setUp(self):
         super(ThermostatTests, self).setUp()
-        self.api_interface = mock.MagicMock()
+        self.api_interface = MagicMock()
 
     def test_thermostat_state(self):
         device_list = []
@@ -59,7 +58,6 @@ class ThermostatTests(unittest.TestCase):
         thermostat2 = get_devices_from_response_dict(response_dict, device_types.THERMOSTAT)[1]
         self.assertTrue(thermostat.away())
         self.assertEqual(thermostat2.away(), None)
-
 
     def test_thermostat_users_away_generic(self):
         device_list = []

--- a/src/pywink/test/devices/water_heater_test.py
+++ b/src/pywink/test/devices/water_heater_test.py
@@ -2,18 +2,17 @@ import json
 import os
 import unittest
 
-import mock
+from unittest.mock import MagicMock
 
-from pywink.api import get_devices_from_response_dict, WinkApiInterface
+from pywink.api import get_devices_from_response_dict
 from pywink.devices import types as device_types
-from pywink.devices.water_heater import WinkWaterHeater
 
 
 class WaterHeaterTests(unittest.TestCase):
 
     def setUp(self):
         super(WaterHeaterTests, self).setUp()
-        self.api_interface = mock.MagicMock()
+        self.api_interface = MagicMock()
 
     def test_current_state(self):
         device_list = []

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='python-wink',
-      version='1.7.0',
+      version='1.7.1',
       description='Access Wink devices via the Wink API',
       url='http://github.com/python-wink/python-wink',
       author='Brad Johnson, William Scanlon',


### PR DESCRIPTION
Turns out that the extra features supported by Schlage locks can't be set via local control... this sets them back to how they were prior to local control i.e. setting them via the online API. 

I also decided to give PyCharm a try and it found a bunch of typos and style "errors" so I fixed those.