### PR TITLE
Add thermostat fields heat_on/cool_on

### DIFF
--- a/src/pywink/devices/thermostat.py
+++ b/src/pywink/devices/thermostat.py
@@ -193,3 +193,9 @@ class WinkThermostat(WinkDevice):
         })
 
         self._update_state_from_response(response)
+
+    def cool_on(self):
+        return self._last_reading.get('cool_active', False)
+
+    def heat_on(self):
+        return self._last_reading.get('heat_active', False)

--- a/src/pywink/test/devices/api_responses/sensi_thermostat.json
+++ b/src/pywink/test/devices/api_responses/sensi_thermostat.json
@@ -43,7 +43,7 @@
       "humidity_updated_at":1477511203.5183966,
       "cool_active":false,
       "cool_active_updated_at":1477511203.5183966,
-      "heat_active":false,
+      "heat_active":true,
       "heat_active_updated_at":1477511203.5183966,
       "aux_active":false,
       "aux_active_updated_at":1477511203.5183966,

--- a/src/pywink/test/devices/thermostat_test.py
+++ b/src/pywink/test/devices/thermostat_test.py
@@ -322,3 +322,23 @@ class ThermostatTests(unittest.TestCase):
         response_dict["data"] = device_list
         thermostat = get_devices_from_response_dict(response_dict, device_types.THERMOSTAT)[0]
         self.assertTrue(thermostat.is_on())
+
+    def test_thermostat_heat_on(self):
+        device_list = []
+        response_dict = {}
+        _json_file = open('{}/api_responses/sensi_thermostat.json'.format(os.path.dirname(__file__)))
+        device_list.append(json.load(_json_file))
+        _json_file.close()
+        response_dict["data"] = device_list
+        thermostat = get_devices_from_response_dict(response_dict, device_types.THERMOSTAT)[0]
+        self.assertTrue(thermostat.heat_on())
+
+    def test_thermostat_cool_on(self):
+        device_list = []
+        response_dict = {}
+        _json_file = open('{}/api_responses/sensi_thermostat.json'.format(os.path.dirname(__file__)))
+        device_list.append(json.load(_json_file))
+        _json_file.close()
+        response_dict["data"] = device_list
+        thermostat = get_devices_from_response_dict(response_dict, device_types.THERMOSTAT)[0]
+        self.assertFalse(thermostat.cool_on())


### PR DESCRIPTION
I have a Sensi thermostat and I'd like track my HVAC usage in Home Assistant to see how often heating and cooling are running. Similar to fan_on ("fan_active"), these expose the "heat_active" and "cool_active" last reading fields. With these I can then patch the HA wink components to use the fields as sensors.