### PR TITLE
Expose GE Z-Wave in wall fan switch as a fan

### DIFF
--- a/src/pywink/api.py
+++ b/src/pywink/api.py
@@ -6,7 +6,7 @@ import urllib.parse
 import requests
 
 from pywink.devices import types as device_types
-from pywink.devices.factory import build_device
+from pywink.devices.factory import build_device, get_object_type
 
 try:
     import urllib3
@@ -629,7 +629,7 @@ def get_devices_from_response_dict(response_dict, device_type):
     api_interface = WinkApiInterface()
 
     for item in items:
-        if item.get("object_type") in device_type:
+        if get_object_type(item) in device_type:
             _devices = build_device(item, api_interface)
             for device in _devices:
                 devices.append(device)

--- a/src/pywink/devices/fan.py
+++ b/src/pywink/devices/fan.py
@@ -94,3 +94,66 @@ class WinkFan(WinkDevice):
         })
 
         self._update_state_from_response(resp)
+
+
+# pylint: disable=too-many-public-methods
+class WinkGeZwaveFan(WinkFan):
+    """
+    Represents a GE-Z-Wave In wall fan switch. Wink recognizes this as a light
+    bulb dimmer switch but in reality it is a fan with 3 speeds.
+    """
+    _to_brightness = {
+        "lowest": 0.33,
+        "low": 0.33,
+        "medium": 0.66,
+        "high": 1.0,
+        "auto": 0.66
+    }
+
+    _to_speed = {
+        0.33: "low",
+        0.66: "medium",
+        1.0: "high"
+    }
+
+    def fan_speeds(self):
+        return ["low", "medium", "high"]
+
+    def fan_directions(self):
+        return []
+
+    def fan_timer_range(self):
+        return []
+
+    def current_fan_speed(self):
+        return self._to_speed[self._last_reading.get('brightness', 0.33)]
+
+    def current_fan_direction(self):
+        return None
+
+    def current_timer(self):
+        return None
+
+    def set_state(self, state, speed=None):
+        """
+        :param state: bool
+        :param speed: a string one of ["lowest", "low",
+            "medium", "high", "auto"] defaults to last speed
+        :return: nothing
+        """
+        desired_state = {"powered": state}
+        if state:
+            brightness = self._to_brightness.get(speed or self.current_fan_speed(), 0.33)
+            desired_state.update({'brightness': brightness})
+
+        response = self.api_interface.set_device_state(self, {
+            "desired_state": desired_state
+        })
+
+        self._update_state_from_response(response)
+
+    def set_fan_direction(self, direction):
+        pass
+
+    def set_fan_timer(self, timer):
+        pass

--- a/src/pywink/test/devices/api_responses/ge_zwave_fan.json
+++ b/src/pywink/test/devices/api_responses/ge_zwave_fan.json
@@ -1,0 +1,65 @@
+{
+   "device_manufacturer":"ge",
+   "upc_id":"11",
+   "manufacturer_device_id":null,
+   "capabilities":{
+
+   },
+   "order":0,
+   "linked_service_id":null,
+   "model_name":"In-Wall Fan Control",
+   "hidden_at":null,
+   "light_bulb_id":"239549",
+   "locale":"en_us",
+   "icon_id":"18",
+   "triggers":[
+
+   ],
+   "icon_code":"light_bulb-fan_light",
+   "uuid":"4bf38640-ad82-xxxxxxx-yyyyyy",
+   "radio_type":"zwave",
+   "gang_id":null,
+   "local_id":"25",
+   "object_type":"light_bulb",
+   "location":"",
+   "upc_code":"ge_jasco-in-wall-fan2",
+   "units":{
+
+   },
+   "manufacturer_device_model":"ge_jasco_in_wall_fan",
+   "created_at":1504074521,
+   "object_id":"2928587",
+   "updated_at":1510211919,
+   "lat_lng":[
+      null,
+      null
+   ],
+   "name":"Ceiling Fan",
+   "primary_upc_code":"ge_jasco-in-wall-fan",
+   "hub_id":"302528",
+   "last_reading":{
+      "powered":false,
+      "desired_brightness_updated_at":1528308568.0060544,
+      "desired_brightness_changed_at":1528308568.0060544,
+      "connection_updated_at":1528308785.0084982,
+      "powered_updated_at":1528308785.0084982,
+      "brightness_updated_at":1528308785.0084982,
+      "connection":true,
+      "desired_powered_changed_at":1528308566.4751642,
+      "connection_changed_at":1526605027.361241,
+      "desired_powered_updated_at":1528308739.3037217,
+      "powered_changed_at":1528308768.4366276,
+      "brightness_changed_at":1528308567.9741776,
+      "brightness":0.66
+   },
+   "desired_state":{
+      "powered":false,
+      "brightness":0.66
+   },
+   "subscription": {
+     "pubnub": {
+      "subscribe_key": "sub-c-f7bf7f7e-054XXXXXXXXXXXXXX",
+      "channel": "024254c58e06548f0aXXXXXXXXXXXXXXXXX0ce|light_bulb-239549|user-123456"
+    }
+  }
+}

--- a/src/pywink/test/devices/base_test.py
+++ b/src/pywink/test/devices/base_test.py
@@ -12,7 +12,7 @@ from pywink.devices.piggy_bank import WinkPorkfolioBalanceSensor, WinkPorkfolioN
 from pywink.devices.siren import WinkSiren
 from pywink.devices.eggtray import WinkEggtray
 from pywink.devices.remote import WinkRemote
-from pywink.devices.fan import WinkFan
+from pywink.devices.fan import WinkFan, WinkGeZwaveFan
 from pywink.devices.binary_switch import WinkBinarySwitch
 from pywink.devices.hub import WinkHub
 from pywink.devices.light_bulb import WinkLightBulb
@@ -82,7 +82,7 @@ class BaseTests(unittest.TestCase):
 
     def test_all_devices_battery_is_valid(self):
         devices = get_devices_from_response_dict(self.response_dict, device_types.ALL_SUPPORTED_DEVICES)
-        skip_types = [WinkFan, WinkPorkfolioBalanceSensor, WinkPorkfolioNose, WinkBinarySwitch, WinkHub,
+        skip_types = [WinkFan, WinkGeZwaveFan, WinkPorkfolioBalanceSensor, WinkPorkfolioNose, WinkBinarySwitch, WinkHub,
                       WinkLightBulb, WinkThermostat, WinkKey, WinkPowerStrip, WinkPowerStripOutlet,
                       WinkRemote, WinkShade, WinkSprinkler, WinkButton, WinkGang, WinkCanaryCamera,
                       WinkAirConditioner, WinkScene, WinkRobot, WinkWaterHeater]
@@ -118,7 +118,8 @@ class BaseTests(unittest.TestCase):
     def test_all_devices_manufacturer_device_id_state_is_valid(self):
         devices = get_devices_from_response_dict(self.response_dict, device_types.ALL_SUPPORTED_DEVICES)
         skip_types = [WinkKey, WinkPowerStrip, WinkPowerStripOutlet, WinkPorkfolioBalanceSensor, WinkPorkfolioNose,
-                      WinkSiren, WinkEggtray, WinkRemote, WinkButton, WinkAirConditioner, WinkPropaneTank]
+                      WinkSiren, WinkEggtray, WinkRemote, WinkButton, WinkAirConditioner, WinkPropaneTank,
+                      WinkGeZwaveFan]
         skip_manufactuer_device_models = ["linear_wadwaz_1",  "linear_wapirz_1", "aeon_labs_dsb45_zwus", "wink_hub", "wink_hub2", "sylvania_sylvania_ct",
                                           "ge_bulb", "quirky_ge_spotter", "schlage_zwave_lock", "home_decorators_home_decorators_fan",
                                           "sylvania_sylvania_rgbw", "somfy_bali", "wink_relay_sensor", "wink_project_one", "kidde_smoke_alarm",

--- a/src/pywink/test/devices/ge_zwave_fan_test.py
+++ b/src/pywink/test/devices/ge_zwave_fan_test.py
@@ -1,0 +1,47 @@
+import json
+import os
+import unittest
+
+from unittest.mock import MagicMock
+
+from pywink.api import get_devices_from_response_dict
+from pywink.devices import types as device_types
+
+
+class GeZwaveFanTests(unittest.TestCase):
+
+    def setUp(self):
+        super(GeZwaveFanTests, self).setUp()
+        self.api_interface = MagicMock()
+        device_list = []
+        self.response_dict = {}
+        _json_file = open('{}/api_responses/ge_zwave_fan.json'.format(os.path.dirname(__file__)))
+        device_list.append(json.load(_json_file))
+        _json_file.close()
+        self.response_dict["data"] = device_list
+
+    def test_fan_speeds(self):
+        fan = get_devices_from_response_dict(self.response_dict, device_types.FAN)[0]
+        has_speeds = fan.fan_speeds()
+        self.assertEqual(len(has_speeds), 3)
+        speeds = ['low', 'medium', 'high']
+        for speed in has_speeds:
+            self.assertTrue(speed in speeds)
+
+    def test_fan_directions(self):
+        fan = get_devices_from_response_dict(self.response_dict, device_types.FAN)[0]
+        has_directions = fan.fan_directions()
+        self.assertEqual(len(has_directions), 0)
+
+    def test_fan_timer_range(self):
+        fan = get_devices_from_response_dict(self.response_dict, device_types.FAN)[0]
+        has_timer_range = fan.fan_timer_range()
+        self.assertEqual(len(has_timer_range), 0)
+
+    def test_fan_speed_is_medium(self):
+        fan = get_devices_from_response_dict(self.response_dict, device_types.FAN)[0]
+        self.assertEqual(fan.current_fan_speed(), "medium")
+
+    def test_fan_state(self):
+        fan = get_devices_from_response_dict(self.response_dict, device_types.FAN)[0]
+        self.assertFalse(fan.state())


### PR DESCRIPTION
Wink recognizes this as a dimmer switch for some reason. But in
reality it is just a fan switch with 3 speeds (translating to
brightness levels of 33%, 66% and 100% in the dimmer switch).

This patch extends WinkFan to specialize the case of GE Z-Wave
in wall fan switch and exposes it as a fan instead of a light
bulb. I've also added a sample json for the tests.

This way home assistant will expose this as a fan without any
changes on the user's part.

Example device: https://www.amazon.com/GE-Controls-Required-SmartThings-14287/dp/B06XTKQTTV/ref=sr_1_1_sspa