### PR TITLE
Allow any brightness value for ge z-wave fan

### DIFF
--- a/src/pywink/devices/fan.py
+++ b/src/pywink/devices/fan.py
@@ -110,12 +110,6 @@ class WinkGeZwaveFan(WinkFan):
         "auto": 0.66
     }
 
-    _to_speed = {
-        0.33: "low",
-        0.66: "medium",
-        1.0: "high"
-    }
-
     def fan_speeds(self):
         return ["low", "medium", "high"]
 
@@ -126,7 +120,12 @@ class WinkGeZwaveFan(WinkFan):
         return []
 
     def current_fan_speed(self):
-        return self._to_speed[self._last_reading.get('brightness', 0.33)]
+        brightness = self._last_reading.get('brightness', 0.33)
+        if brightness <= 0.33:
+            return "low"
+        elif brightness <= 0.66:
+            return "medium"
+        return "high"
 
     def current_fan_direction(self):
         return None

--- a/src/pywink/test/devices/api_responses/ge_zwave_fan.json
+++ b/src/pywink/test/devices/api_responses/ge_zwave_fan.json
@@ -50,7 +50,7 @@
       "desired_powered_updated_at":1528308739.3037217,
       "powered_changed_at":1528308768.4366276,
       "brightness_changed_at":1528308567.9741776,
-      "brightness":0.66
+      "brightness":0.1
    },
    "desired_state":{
       "powered":false,

--- a/src/pywink/test/devices/ge_zwave_fan_test.py
+++ b/src/pywink/test/devices/ge_zwave_fan_test.py
@@ -38,9 +38,9 @@ class GeZwaveFanTests(unittest.TestCase):
         has_timer_range = fan.fan_timer_range()
         self.assertEqual(len(has_timer_range), 0)
 
-    def test_fan_speed_is_medium(self):
+    def test_fan_speed_is_low(self):
         fan = get_devices_from_response_dict(self.response_dict, device_types.FAN)[0]
-        self.assertEqual(fan.current_fan_speed(), "medium")
+        self.assertEqual(fan.current_fan_speed(), "low")
 
     def test_fan_state(self):
         fan = get_devices_from_response_dict(self.response_dict, device_types.FAN)[0]


### PR DESCRIPTION
Brightness can be anything from 0.0 to 1.0 when it is set from
the wink app's UI. Handle all the values instead of assuming a
discrete set of values supported by this library.

Fixes #107